### PR TITLE
Use uniform keys for LARA entities (source_key, id).

### DIFF
--- a/functions/src/api/helpers/lara-types.ts
+++ b/functions/src/api/helpers/lara-types.ts
@@ -1,18 +1,21 @@
 export type ILaraResourceType = 'Activity' | 'Sequence';
 
-export interface IPartialLaraAuthoredResource {
+export interface IStandardLaraKeys {
+  id: string;
+  source_key: string;
+}
+
+export interface IPartialLaraAuthoredResource extends IStandardLaraKeys{
   url: string;
   author_email: string;
   type: ILaraResourceType;
 }
 
-export interface IPartialLaraRun {
+export interface IPartialLaraRun extends IStandardLaraKeys{
   url: string;
-  key: string;
-  answers: IPartialLaraAnswer[]
+  answers: IPartialLaraAnswer[];
 }
 
-export interface IPartialLaraAnswer {
-  url: string;
-  key: string;
+export interface IPartialLaraAnswer extends IStandardLaraKeys {
+  question_key: string;
 }

--- a/functions/src/api/helpers/paths.ts
+++ b/functions/src/api/helpers/paths.ts
@@ -5,29 +5,9 @@ import {
   IPartialLaraAuthoredResource
 } from './lara-types';
 
-const resourceKey = (url:string) => {
+const getPath = (source_key:string, type:string, id:string) => {
   return new Promise<string>((resolve, reject) => {
-    const re = /(https?:\/\/)(.*)/
-    const match = url.match(re) || []
-    const hostPath = match[2]
-    if (hostPath) {
-      resolve(hostPath.replace(/\.|\//g, '_'))
-    } else {
-      reject(`hostPath not found in url, or url missing ${url}`)
-    }
-  })
-}
-
-const genSourceKey = (url:string) => {
-  return new Promise<string>((resolve, reject) => {
-    const re = /https?:\/\/([^/]+)/
-    const match = url.match(re) || []
-    const hostPart = match[1]
-    if (hostPart) {
-      resolve(hostPart.replace(/\./g, '_'))
-    } else {
-      reject(`Host Name not found in url, or url missing ${url}`)
-    }
+    resolve(`/sources/${source_key}/${type}/${id}`)
   })
 }
 
@@ -35,21 +15,17 @@ export const getDoc = (path: string) => {
   return admin.firestore().doc(path)
 }
 
-export const getSourcePath = (url: string) => {
-  return genSourceKey(url).then((sourceKey) => `/sources/${sourceKey}`)
-}
-
 export const getResourcePath = (resource: IPartialLaraAuthoredResource) => {
-  return getSourcePath(resource.url).then((sourcePath) => {
-    return resourceKey(resource.url).then((key) => `${sourcePath}/resources/${key}`)
-  })
+  const {source_key, id}  = resource
+  return getPath(source_key, "resources", id)
 }
 
 export const getRunPath = (run: IPartialLaraRun) => {
-  return getSourcePath(run.url).then((sourcePath) => `${sourcePath}/runs/${run.key}`)
+  const {source_key, id}  = run;
+  return getPath(source_key, "runs", id);
 }
 
 export const getAnswerPath = (answer: IPartialLaraAnswer) => {
-  return getSourcePath(answer.url)
-    .then((sourcePath) => `${sourcePath}/answers/${answer.key}`)
+  const {source_key, id}  = answer;
+  return getPath(source_key, "answers", id);
 }


### PR DESCRIPTION
We were doing the same URL munging in both LARA and the report service to get `source_key`s.

Some of the portal entities (`answers`) didn't actually have URLs to support computing the `source_key` in FireStore.

This commit changes the interfaces to require common and explicit keys.

[#166063708]

https://www.pivotaltracker.com/story/show/166063708