### PR TITLE
Increase api gateway timeout from 3 seconds to 300 seconds [#173924040]

### DIFF
--- a/query-creator/template.yaml
+++ b/query-creator/template.yaml
@@ -20,7 +20,7 @@ Parameters:
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
   Function:
-    Timeout: 3
+    Timeout: 300
     Environment:
       Variables:
         JWT_HMAC_SECRET: !Ref JwtHmacSecret


### PR DESCRIPTION
The "internal server error" we saw was actually not caused by the function but rather by the api gateway timing out.  The default timeout is 3 seconds, I increased this to 300 (5 minutes).