### PR TITLE
Update learner and anonymous answer rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -22,7 +22,7 @@ service cloud.firestore {
               && string(request.auth.token.platform_user_id) == string(request.resource.data.platform_user_id)
               && request.auth.token.class_hash == request.resource.data.context_id;
       // anonymous requests based on run_key, which must be larger than 10 chars
-      allow read, update: if resource.data.run_key.size() > 10;
+      allow read, update: if resource.data.run_key.size() > 10 && resource.data.run_key == request.resource.data.run_key;
       allow create: if request.resource.data.run_key.size() > 10;
     }  
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -16,10 +16,10 @@ service cloud.firestore {
       allow read: if request.auth.token.user_type == 'teacher' && request.auth.token.class_hash == resource.data.context_id;
       allow read: if request.auth.token.user_type == 'learner' && string(request.auth.token.platform_user_id) == string(resource.data.platform_user_id);
       allow update: if request.auth.token.user_type == 'learner'
-      				&& string(request.auth.token.platform_user_id) == string(resource.data.platform_user_id)
+              && string(request.auth.token.platform_user_id) == string(resource.data.platform_user_id)
               && request.auth.token.class_hash == resource.data.context_id;
       allow create: if request.auth.token.user_type == 'learner'
-      				&& string(request.auth.token.platform_user_id) == string(request.resource.data.platform_user_id)
+              && string(request.auth.token.platform_user_id) == string(request.resource.data.platform_user_id)
               && request.auth.token.class_hash == request.resource.data.context_id;
       // anonymous requests based on run_key, which must be larger than 10 chars
       allow read, update: if resource.data.run_key.size() > 10;

--- a/firestore.rules
+++ b/firestore.rules
@@ -13,8 +13,17 @@ service cloud.firestore {
       allow read: if request.auth.uid != null && request.auth.token.firebase.sign_in_provider != 'anonymous';
     }
     match /sources/{source}/answers/{document=**} {
-      allow read: if request.auth.token.user_type == 'teacher' && request.auth.token.class_hash == resource.data.context_id ||
-                     request.auth.token.user_type == 'learner' && string(request.auth.token.platform_user_id) == string(resource.data.platform_user_id);
+      allow read: if request.auth.token.user_type == 'teacher' && request.auth.token.class_hash == resource.data.context_id;
+      allow read: if request.auth.token.user_type == 'learner' && string(request.auth.token.platform_user_id) == string(resource.data.platform_user_id);
+      allow update: if request.auth.token.user_type == 'learner'
+      				&& string(request.auth.token.platform_user_id) == string(resource.data.platform_user_id)
+              && request.auth.token.class_hash == resource.data.context_id;
+      allow create: if request.auth.token.user_type == 'learner'
+      				&& string(request.auth.token.platform_user_id) == string(request.resource.data.platform_user_id)
+              && request.auth.token.class_hash == request.resource.data.context_id;
+      // anonymous requests based on run_key, which must be larger than 10 chars
+      allow read, update: if resource.data.run_key.size() > 10;
+      allow create: if request.resource.data.run_key.size() > 10;
     }  
 
     // This lets us limit access to report settings based on user and offering.


### PR DESCRIPTION
This modifies the answer rules such that

1. A learner can now update and create content, but only within their current class
2. Unauthenticated users can read, update and create any content with a run key. I arbitrary required a minimum of 10 characters for the run-key, to prevent any code that might accidentally use an empty string, or something non-random like the class id.