### PR TITLE
Fixed two errors found when doing prod deployment

### DIFF
--- a/query-creator/create-query/app.js
+++ b/query-creator/create-query/app.js
@@ -69,10 +69,10 @@ exports.lambdaHandler = async (event, context) => {
     console.log(err);
     return {
       statusCode: 500,
-      body: {
+      body: JSON.stringify({
         error: err.toString(),
         stack: err.stack
-      }
+      }, null, 2)
     }
   }
 };

--- a/query-creator/create-query/steps/firebase.js
+++ b/query-creator/create-query/steps/firebase.js
@@ -27,7 +27,7 @@ exports.getResource = async (runnable, reportServiceSource, demo) => {
       }
     )
   } catch (e) {
-    throw new Error(`Unable to get resource at ${url} using ${JSON.stringify(params)}. Error: ${e.toString()}. Response: ${error.response ? JSON.stringify(error.response.data) : "no response"}`)
+    throw new Error(`Unable to get resource at ${url} using ${JSON.stringify(params)}. Error: ${e.toString()}. Response: ${e.response ? JSON.stringify(e.response.data) : "no response"}`)
   }
   const result = response.data
   if (result && result.success && result.resource) {


### PR DESCRIPTION
1. The body of the try/catch error wrapper needs to be a string (it was an object which caused the "Internal server error" message)
2. The rethrown error in the getResource Firebase call referenced an unknown variable