### PR TITLE
Support Activity Player

### DIFF
--- a/functions/README.md
+++ b/functions/README.md
@@ -29,8 +29,8 @@ to the `concordqa-report-data` S3 bucket.
 
 We can download the AWS key and Secret Key for this user (check 1Password), and then push it up to Firebase with
 
-`firebase functions:config:set auth.aws.key=<VALUE>`
-`firebase functions:config:set auth.aws.seret_key=<VALUE>`
+`firebase functions:config:set aws.key=<VALUE>`
+`firebase functions:config:set aws.secret_key=<VALUE>`
 
 These three values are now accessible to the Functions via `functions.config().aws.s3_bucket`, `key` and `secret_key`
 

--- a/functions/src/auto-importer.ts
+++ b/functions/src/auto-importer.ts
@@ -68,7 +68,7 @@ interface SyncData {
 
 type PartialSyncData = Partial<SyncData>;
 
-const getHash = (data: any) => {
+export const getHash = (data: any) => {
   const hash = crypto.createHash('sha256');
   hash.update(JSON.stringify(data));
   return hash.digest('hex');
@@ -256,7 +256,7 @@ export const monitorSyncDocCount = functions.pubsub.schedule(monitorSyncDocSched
 });
 
 export const syncToS3AfterSyncDocWritten = functions.firestore
-  .document(`${answersSyncPathAllSources}/{id}`) // NOTE: {answerId} is a wildcard passed to Firebase
+  .document(`${answersSyncPathAllSources}/{id}`) // {id} is a wildcard passed to Firebase.
   .onWrite((change, context) => {
     return getSettings()
       .then(({ sync }) => {

--- a/functions/src/auto-importer.ts
+++ b/functions/src/auto-importer.ts
@@ -156,7 +156,13 @@ const syncToS3 = (answers: AnswerData[]): Promise<S3SyncInfo> => {
       await deleteFile();
       const writer = await parquet.ParquetWriter.openFile(schema, tmpFilePath);
       for (const answer of answers) {
+        // clean up answer objects for parquet
         answer.answer = JSON.stringify(answer.answer)
+        delete answer.report_state;
+        if (typeof answer.version === "number") {
+          answer.version = "" + answer.version;
+        }
+
         await writer.appendRow(answer);
       }
       await writer.close();

--- a/functions/src/auto-importer.ts
+++ b/functions/src/auto-importer.ts
@@ -14,22 +14,22 @@ const access = util.promisify(fs.access);
 const unlink = util.promisify(fs.unlink);
 const readFile = util.promisify(fs.readFile);
 
-import { AnswerData, schema, parquetInfo } from "./shared/s3-answers"
+import { AnswerData, schema, parquetInfo, AnswerMetadata, getAnswerMetadata, getSyncDocId } from "./shared/s3-answers"
 
 /*
 
 HOW THIS WORKS:
 
 1. createSyncDocAfterAnswerWritten runs on every write of an answer.  If the answer changes or is deleted a "sync doc"
-   is created or updated whose name is the run_key for the answer along with a boolean "updated". For logging purposes,
-   it will also add a last_answer_updated timestamp.
+   is created or updated whose name is a unique key for the learner-assignment (either a hash of the LTI data or a
+    runKey) along with a boolean "updated". For logging purposes, it will also add a last_answer_updated timestamp.
 2. monitorSyncDocCount runs as a cron job every few minutes to find all the docs with updated = true.  Each document that is
    found has a needs_sync field set to the current server time and has updated set to false.
 3. syncToS3AfterSyncDocWritten runs on every write of a sync doc.  If the needs_sync field exists and either the doc has
-   never synced before, or needs_sync > did_sync, it will gather up all the answers for that runKey and post them to
-   s3 as a parquet file. If there are no answers, it will delete the parquet file. It will then set a did_sync timestamp.
-   For logging purposes, it will also set a start_sync timestamp the momement it starts handling the sync_doc, and when
-   it finishes it will add some timing info.
+   never synced before, or needs_sync > did_sync, it will gather up all the answers for that learner-assignment and post
+   them to s3 as a parquet file. If there are no answers, it will delete the parquet file. It will then set a did_sync
+   timestamp. For logging purposes, it will also set a start_sync timestamp the momement it starts handling the sync_doc,
+   and when it finishes it will add some timing info.
 */
 
 const answerDirectory = "partitioned-answers"
@@ -58,7 +58,7 @@ interface S3SyncInfo {
 
 interface SyncData {
   updated: boolean;
-  resource_url: string;
+  answer_metadata: AnswerMetadata;
   last_answer_updated: firestore.Timestamp;
   need_sync?: firestore.Timestamp;
   did_sync?: firestore.Timestamp;
@@ -94,12 +94,21 @@ const getSettings = () => {
     .catch(() => defaultSettings)
 }
 
-const addSyncDoc = (syncSource: string, runKey: string, resourceUrl: string) => {
-  const syncDocRef = getAnswerSyncCollection(syncSource).doc(runKey);
+/**
+ * Creates a document in answers_async letting the app know there are answers to be synced
+ *
+ * @param syncSource The source collection from whence the answer came
+ * @param answerMetadata A collection of identifiers that lets us uniquely identify a learner-assignment or anon user
+ */
+const addSyncDoc = (syncSource: string, answerMetadata: AnswerMetadata) => {
+  const syncDocId = getHash(getSyncDocId(answerMetadata));
+  if (!syncDocId || !answerMetadata) return;
+
+  const syncDocRef = getAnswerSyncCollection(syncSource).doc(syncDocId);
   let syncDocData: SyncData = {
     updated: true,
     last_answer_updated: firestore.Timestamp.now(),
-    resource_url: resourceUrl
+    answer_metadata: answerMetadata
   };
 
   return admin.firestore().runTransaction((transaction) => {
@@ -130,7 +139,6 @@ const s3Client = () => new S3Client({
 });
 
 const syncToS3 = (answers: AnswerData[]): Promise<S3SyncInfo> => {
-  const {run_key} = answers[0]
   const {filename, key} = parquetInfo(answerDirectory, answers[0]);
   const tmpFilePath = path.join("/tmp", filename);
 
@@ -175,7 +183,7 @@ const syncToS3 = (answers: AnswerData[]): Promise<S3SyncInfo> => {
         s3SendFileTotalTime
       }
     } catch (err) {
-      reject(`${run_key}: ${err.toString()}`);
+      reject(err.toString());
     } finally {
       await deleteFile();
       resolve(resultsInfo);
@@ -183,8 +191,8 @@ const syncToS3 = (answers: AnswerData[]): Promise<S3SyncInfo> => {
   });
 }
 
-const deleteFromS3 = (runKey: string, resourceUrl: string) => {
-  const {key} = parquetInfo(answerDirectory, null, runKey, resourceUrl);
+const deleteFromS3 = (answerMetadata: AnswerMetadata) => {
+  const {key} = parquetInfo(answerDirectory, answerMetadata);
   const deleteObjectCommand = new DeleteObjectCommand({
     Bucket: functions.config().aws.s3_bucket,
     Key: key
@@ -198,13 +206,11 @@ export const createSyncDocAfterAnswerWritten = functions.firestore
     return getSettings()
       .then(({ watchAnswers }) => {
         if (watchAnswers) {
-          // need to get the before data in case answer was deleted
-          const runKey = change.before.data()?.run_key;
-          // likewise, if the answer was deleted, we need to record where it used to be, to potentially delete the doc
-          const resourceUrl = change.before.data()?.resource_url;
+          // need to get the before location data in case answer was deleted
+          const previousAnswer = change.before.data();
+          const answerMetadata = previousAnswer && getAnswerMetadata(previousAnswer as AnswerData);
 
-
-          if (!runKey) {
+          if (!answerMetadata) {
             return null;
           }
 
@@ -212,7 +218,7 @@ export const createSyncDocAfterAnswerWritten = functions.firestore
           const afterHash = getHash(change.after.data());
 
           if (afterHash !== beforeHash) {
-            return addSyncDoc(context.params.syncSource, runKey, resourceUrl);
+            return addSyncDoc(context.params.syncSource, answerMetadata);
           }
         }
 
@@ -244,7 +250,7 @@ export const monitorSyncDocCount = functions.pubsub.schedule(monitorSyncDocSched
 });
 
 export const syncToS3AfterSyncDocWritten = functions.firestore
-  .document(`${answersSyncPathAllSources}/{runKey}`) // NOTE: {answerId} is a wildcard passed to Firebase
+  .document(`${answersSyncPathAllSources}/{id}`) // NOTE: {answerId} is a wildcard passed to Firebase
   .onWrite((change, context) => {
     return getSettings()
       .then(({ sync }) => {
@@ -255,15 +261,27 @@ export const syncToS3AfterSyncDocWritten = functions.firestore
           const needSyncMoreRecentThanStartSync = data.need_sync && (!data.start_sync || (data.need_sync > data.start_sync));
 
           if (data.need_sync && needSyncMoreRecentThanDidSync && needSyncMoreRecentThanStartSync) {
-            const syncDocRef = getAnswerSyncCollection(context.params.syncSource).doc(context.params.runKey);
+            const syncDocRef = change.after.ref;
 
             syncDocRef.update({
               start_sync: firestore.Timestamp.now()
             } as PartialSyncData).catch(functions.logger.error)
 
+            let getAllAnswersForLearner;
+            const { answer_metadata } = data;
+            if (answer_metadata.platform_id && answer_metadata.resource_link_id && answer_metadata.platform_user_id) {
+              getAllAnswersForLearner = getAnswersCollection(context.params.syncSource)
+                .where("platform_id", "==", answer_metadata.platform_id)
+                .where("resource_link_id", "==", answer_metadata.resource_link_id)
+                .where("platform_user_id", "==", answer_metadata.platform_user_id)
+            } else if (answer_metadata.run_key) {
+              getAllAnswersForLearner = getAnswersCollection(context.params.syncSource)
+                .where("run_key", "==", answer_metadata.run_key)
+            }
+            if (!getAllAnswersForLearner) return null;
+
             const syncToS3StartTime = performance.now();
-            return getAnswersCollection(context.params.syncSource)
-              .where("run_key", "==", context.params.runKey)
+            return getAllAnswersForLearner
               .get()
               .then((querySnapshot) => {
                 const answers: firestore.DocumentData[] = [];
@@ -285,7 +303,7 @@ export const syncToS3AfterSyncDocWritten = functions.firestore
                     .catch(functions.logger.error)
                 } else {
                   // if the learner has no answers associated with this run, delete the doc
-                  deleteFromS3(context.params.runKey, data.resource_url)
+                  deleteFromS3(data.answer_metadata)
                     .catch(functions.logger.error);
                 }
               });

--- a/functions/src/shared/s3-answers.ts
+++ b/functions/src/shared/s3-answers.ts
@@ -13,7 +13,8 @@ export interface AnswerMetadata {
 export interface AnswerData extends AnswerMetadata {
   // leaving out everything but the resource_url and run_key which is what we care about
   answer?: any;
-
+  report_state?: any;
+  version?: any;
 }
 
 export const schema = new parquet.ParquetSchema({

--- a/functions/src/shared/s3-answers.ts
+++ b/functions/src/shared/s3-answers.ts
@@ -18,24 +18,24 @@ export interface AnswerData extends AnswerMetadata {
 
 export const schema = new parquet.ParquetSchema({
   submitted: { type: 'BOOLEAN', optional: true },
-  run_key: { type: 'UTF8' },
+  run_key: { type: 'UTF8', optional: true },
   platform_user_id: { type: 'UTF8', optional: true },
   id: { type: 'UTF8' },
   context_id: { type: 'UTF8', optional: true },
   class_info_url: { type: 'UTF8', optional: true },
   platform_id: { type: 'UTF8', optional: true },
   resource_link_id: { type: 'UTF8', optional: true },
-  type: { type: 'UTF8' },
+  type: { type: 'UTF8', optional: true },
   question_id: { type: 'UTF8' },
   source_key: { type: 'UTF8' },
-  question_type: { type: 'UTF8' },
-  tool_user_id: { type: 'UTF8' },
+  question_type: { type: 'UTF8', optional: true },
+  tool_user_id: { type: 'UTF8', optional: true },
   answer: { type: 'UTF8' },
   resource_url: { type: 'UTF8' },
   remote_endpoint: { type: 'UTF8', optional: true },
-  created: { type: 'UTF8' },
+  created: { type: 'UTF8', optional: true },
   tool_id: { type: 'UTF8' },
-  version: { type: 'UTF8' },
+  version: { type: 'UTF8', optional: true },
 });
 
 // replaces everything but alphanumeric chars with -

--- a/functions/src/shared/s3-answers.ts
+++ b/functions/src/shared/s3-answers.ts
@@ -1,3 +1,5 @@
+import { getHash } from "../auto-importer";
+
 const parquet = require('parquetjs');
 
 export interface AnswerMetadata {
@@ -75,10 +77,11 @@ export const parquetInfo = (directory: string, answer: AnswerMetadata) => {
 }
 
 // returns just the part needed to identify the answer uniquely
-// urls don't need to be escaped because the document name will be hashed
 export const getSyncDocId = (answer: AnswerData) => {
   if (answer.platform_id && answer.resource_link_id && answer.platform_user_id) {
-    return `${answer.platform_id}_${answer.resource_url}_${answer.platform_user_id}`;
+    // urls don't need to be escaped because the document name will be hashed
+    const ltiId = `${answer.platform_id}_${answer.resource_url}_${answer.platform_user_id}`;
+    return getHash(ltiId);
   } else if (answer.run_key) {
     return answer.run_key;
   }

--- a/functions/src/shared/s3-answers.ts
+++ b/functions/src/shared/s3-answers.ts
@@ -1,10 +1,19 @@
 const parquet = require('parquetjs');
 
-export interface AnswerData {
+export interface AnswerMetadata {
+  resource_url: string;
+  // logged-in user
+  platform_id?: string;
+  resource_link_id?: string;
+  platform_user_id?: string;
+  // anonymous user
+  run_key?: string;
+}
+
+export interface AnswerData extends AnswerMetadata {
   // leaving out everything but the resource_url and run_key which is what we care about
   answer?: any;
-  resource_url: string;
-  run_key?: string;
+
 }
 
 export const schema = new parquet.ParquetSchema({
@@ -29,23 +38,66 @@ export const schema = new parquet.ParquetSchema({
   version: { type: 'UTF8' },
 });
 
-export const parquetInfo = (directory: string, answer?: AnswerData | null, _runKey?: string, _resourceUrl?: string) => {
-  let runKey, resourceUrl;
-  if (answer) {
-    runKey = answer.run_key;
-    resourceUrl = answer.resource_url;
-  } else {
-    runKey = _runKey;
-    resourceUrl = _resourceUrl;
-  }
-  if (!runKey || !resourceUrl) {
-    throw Error(`Cannot create filename for ${runKey}`);
-  }
+// replaces everything but alphanumeric chars with -
+const escapeUrl = (url: string) => url.replace(/[^a-z0-9]/g, "-")
 
-  const filename = `${runKey}.parquet`;
-  const folder = resourceUrl.replace(/[^a-z0-9]/g, "-");
-  return {
-    filename,
-    key: `${directory}/${folder}/${filename}`
+/**
+ * Returns the filename and directory structure that the parquet file should end up in, given an answer.
+ *
+ * For a logged-in user launching from the portal (LARA or Activity Player):
+ *  answers/[escaped_resource_id]/[platform_id]/[resource_link_id]/[platform_user_id].parquet
+ *
+ * For an anonymous user (LARA or AP):
+ *  answers/[escaped_resource_id]/anonymous/no-resource-link/[run-key].parquet
+ *
+ * @param directory Top-level directory in S3 bucket (partitioned-answers)
+ * @param answer Answer or metadata-only info
+ */
+export const parquetInfo = (directory: string, answer: AnswerMetadata) => {
+  const escaped_resource_id = escapeUrl(answer.resource_url);
+  let filename: string;
+  if (escaped_resource_id && answer.platform_id && answer.resource_link_id && answer.platform_user_id) {
+    filename = `${answer.platform_user_id}.parquet`;
+    return {
+      filename,
+      key: `${directory}/${escaped_resource_id}/${escapeUrl(answer.platform_id)}/${answer.resource_link_id}/${filename}`
+    };
+  } else if (answer.run_key) {
+    filename = `${answer.run_key}.parquet`;
+    return {
+      filename,
+      key: `${directory}/${escaped_resource_id}/anonymous/no-resource-link/${filename}`
+    };
+  } else {
+    throw Error(`Cannot create filename`);
   }
+}
+
+// returns just the part needed to identify the answer uniquely
+// urls don't need to be escaped because the document name will be hashed
+export const getSyncDocId = (answer: AnswerData) => {
+  if (answer.platform_id && answer.resource_link_id && answer.platform_user_id) {
+    return `${answer.platform_id}_${answer.resource_url}_${answer.platform_user_id}`;
+  } else if (answer.run_key) {
+    return answer.run_key;
+  }
+  return null;
+}
+
+// returns just the part needed to identify the answer uniquely
+export const getAnswerMetadata = (answer: AnswerData) => {
+  if (answer.resource_url && answer.platform_id && answer.resource_link_id && answer.platform_user_id) {
+    return {
+      resource_url: answer.resource_url,
+      platform_id: answer.platform_id,
+      resource_link_id: answer.resource_link_id,
+      platform_user_id: answer.platform_user_id
+    };
+  } else if (answer.resource_url && answer.run_key) {
+    return {
+      resource_url: answer.resource_url,
+      run_key: answer.run_key
+    };
+  }
+  return null;
 }

--- a/functions/src/shared/s3-answers.ts
+++ b/functions/src/shared/s3-answers.ts
@@ -80,7 +80,7 @@ export const parquetInfo = (directory: string, answer: AnswerMetadata) => {
 export const getSyncDocId = (answer: AnswerData) => {
   if (answer.platform_id && answer.resource_link_id && answer.platform_user_id) {
     // urls don't need to be escaped because the document name will be hashed
-    const ltiId = `${answer.platform_id}_${answer.resource_url}_${answer.platform_user_id}`;
+    const ltiId = `${answer.platform_id}_${answer.resource_link_id}_${answer.platform_user_id}`;
     return getHash(ltiId);
   } else if (answer.run_key) {
     return answer.run_key;


### PR DESCRIPTION
This supports the Activity Player by using the LTI properties for logged in users that can be combined to identify a learner-assignment (platform_id, resource_link_id and platform_user_id) to find the answers collection and to create the parquet files. For anonymous users we still use the runKey.

For a logged-in user launching from the portal (LARA or Activity Player) we now save parquet files to:

    partitioned_answers/[escaped_resource_id]/[escaped-platform_id]/[escaped_resource_link_id]/[platform_user_id].parquet

For an anonymous user (LARA or AP):

    partitioned_answers/[escaped_resource_id]/anonymous/no-resource-link/[run-key].parquet

A few other changes needed to be made to support finding answers using these properties, and to support the differences in how the AP saves answers (some keys missing, some keys of different types, etc.)

Here are some examples of parquet files to the new very-wordy folder structure in S3:

Logged in user from LARA

https://s3.console.aws.amazon.com/s3/buckets/concordqa-report-data?region=us-east-1&prefix=partitioned-answers/https---authoring-staging-concord-org-sequences-71/https---learn-staging-concord-org/182/&showversions=false

Logged in user from AP:

https://s3.console.aws.amazon.com/s3/buckets/concordqa-report-data?region=us-east-1&prefix=partitioned-answers/https---activity-player-concord-org-branch-authenticate-and-fetch-data--activity-https-3--2--2-authoring-staging-concord-org-2-api-2-v1-2-activities-2-20753-json-firebase-app-report-service-dev-report-source-authoring-staging-concord-org/&showversions=false

Anonymous user from LARA:

https://s3.console.aws.amazon.com/s3/buckets/concordqa-report-data?region=us-east-1&prefix=partitioned-answers/https---authoring-staging-concord-org-activities-20960/&showversions=false