### PR TITLE
Support LTI in export-answers script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
 # Report Service
 Ingest student runs and activity structure in order to run report queries later.
 
+## Scripts
+
+Includes the export-answers script for copying all student answers from Firestore into S3 as Parquet files
+
+See [scripts/README.md](scripts/README.md)
+
 ## Firebase functions
+
+Includes the API and the auto-update function for student answers.
 
 See [functions/README.md](functions/README.md)
 

--- a/functions/package.json
+++ b/functions/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "lint": "tslint --project tsconfig.json",
     "build": "tsc",
+    "build:shared": "tsc src/shared/*.ts",
     "serve": "npm run buildinfo && tsc -w & firebase serve --only functions",
     "shell": "npm run build && firebase functions:shell",
     "start": "npm run shell",

--- a/functions/src/shared/s3-answers.ts
+++ b/functions/src/shared/s3-answers.ts
@@ -1,6 +1,11 @@
-import { getHash } from "../auto-importer";
-
+const crypto = require("crypto");
 const parquet = require('parquetjs');
+
+const getHash = (data: any) => {
+  const hash = crypto.createHash('sha256');
+  hash.update(JSON.stringify(data));
+  return hash.digest('hex');
+}
 
 export interface AnswerMetadata {
   resource_url: string;

--- a/functions/src/shared/s3-answers.ts
+++ b/functions/src/shared/s3-answers.ts
@@ -1,7 +1,7 @@
 const crypto = require("crypto");
 const parquet = require('parquetjs');
 
-const getHash = (data: any) => {
+export const getHash = (data: any) => {
   const hash = crypto.createHash('sha256');
   hash.update(JSON.stringify(data));
   return hash.digest('hex');
@@ -81,9 +81,13 @@ export const parquetInfo = (directory: string, answer: AnswerMetadata) => {
   }
 }
 
+export const hasLTIMetadata = (answer: AnswerData) => {
+  return !!(answer.platform_id && answer.resource_link_id && answer.platform_user_id);
+}
+
 // returns just the part needed to identify the answer uniquely
 export const getSyncDocId = (answer: AnswerData) => {
-  if (answer.platform_id && answer.resource_link_id && answer.platform_user_id) {
+  if (hasLTIMetadata(answer)) {
     // urls don't need to be escaped because the document name will be hashed
     const ltiId = `${answer.platform_id}_${answer.resource_link_id}_${answer.platform_user_id}`;
     return getHash(ltiId);
@@ -95,7 +99,7 @@ export const getSyncDocId = (answer: AnswerData) => {
 
 // returns just the part needed to identify the answer uniquely
 export const getAnswerMetadata = (answer: AnswerData) => {
-  if (answer.resource_url && answer.platform_id && answer.resource_link_id && answer.platform_user_id) {
+  if (answer.resource_url && hasLTIMetadata(answer)) {
     return {
       resource_url: answer.resource_url,
       platform_id: answer.platform_id,

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,27 @@
+# Running the export-answers script
+
+This script finds all student answers in a Firetore report-service database, collects all the answers for a single
+user's assignment into a single Parquet file, and uploads all the files to S3 for querying by the Athena database.
+
+```
+// build the shared library
+cd functions
+npm install
+npm run build:shared
+
+// build the scripts
+cd scripts
+npm install
+```
+
+Copy the `config.json.sample` file to `config.json` and fill in the AWS credentials for the S3 bucket. This should
+be available in 1Password as one of the report-service AWS accounts.
+
+Download the `credentials.json` file for the appropriate Firebase project from e.g.
+https://console.cloud.google.com/apis/credentials?project=report-service-pro&organizationId=264971417743
+
+Run the script by passing in the destination S3 bucket and the source key for the Firestore database. e.g.
+
+```
+node export-answers.js concordqa-report-data authoring.staging.concord.org
+```

--- a/scripts/export-answers.js
+++ b/scripts/export-answers.js
@@ -1,24 +1,27 @@
 #!/usr/bin/env node
-
-const BUCKET = "concordqa-report-data"
-const SOURCE = "authoring.staging.concord.org"
-const DIRECTORY = "partitioned-answers"
-const BATCH_SIZE = 100;
-
-var AWS = require('aws-sdk');
+const AWS = require('aws-sdk');
 const {Firestore} = require('@google-cloud/firestore');
 const fs = require('fs');
 const path = require('path');
-
-const zlib = require('zlib');
 const util = require('util');
+
+const BUCKET = process.argv[2];     // e.g. concordqa-report-data
+const SOURCE =  process.argv[3];    // e.g. authoring.staging.concord.org
+
+if (!BUCKET || !SOURCE) {
+  console.error("Call script with `node export-answers.js [bucket-name] [source-id]`");
+  return;
+}
+
+const DIRECTORY = "partitioned-answers"
+const BATCH_SIZE = 100;
 
 const access = util.promisify(fs.access);
 const unlink = util.promisify(fs.unlink);
 const readFile = util.promisify(fs.readFile);
 
 const parquet = require('parquetjs');
-const { parquetInfo, schema } = require('../functions/src/shared/s3-answers')
+const { parquetInfo, getSyncDocId, schema } = require('../functions/src/shared/s3-answers')
 
 const awsConfig = "./config.json"
 if (!fs.existsSync(awsConfig)) {
@@ -45,31 +48,41 @@ const firestore = new Firestore();
 
 let query = firestore.collection(`sources/${SOURCE}/answers`);
 let masterQuery = query.limit(BATCH_SIZE)
-  .orderBy('run_key').orderBy("id")
+  .orderBy("resource_url")
+  .orderBy("platform_id")
+  .orderBy("resource_link_id")
+  .orderBy("platform_user_id")
+  .orderBy("run_key")
+  .orderBy("id")
 
 let count = 0;
 let lastDoc = null;
 let batchCount = 0;
 let batchIndex = 0;
-let lastRunKey = undefined;
+let lastUserRunKey = undefined;   // id for the a user's whole answer set, whether a run key or an hashed LTI combo
 const answerHash = {};
 const uploadPromises = {};
 
 // set to true once all uploads have been created and the system is waiting for the uploads to finish
 let waitingForUploadsToFinish = false;
 
-function uploadAnswers(runKey) {
-  if (!answerHash[runKey] || (answerHash[runKey].length === 0)) {
+function uploadAnswers(userRunKey) {
+  if (!answerHash[userRunKey] || (answerHash[userRunKey].length === 0)) {
     return;
   }
 
-  const answers = answerHash[runKey];
+  const answers = answerHash[userRunKey];
   const answer = answers[0];
-  const {filename, key} = parquetInfo(answer, DIRECTORY);
+  const info = parquetInfo(DIRECTORY, answer);
+  if (!info) {
+    return;
+  }
+  const {filename, key} = info;
+
   const tmpFilePath = path.join(outputPath, filename);
 
-  if (uploadPromises[runKey]) {
-    console.error("Already uploading", runKey)
+  if (uploadPromises[userRunKey]) {
+    console.error("Already uploading", userRunKey)
     return;
   }
 
@@ -77,13 +90,19 @@ function uploadAnswers(runKey) {
     return access(tmpFilePath).then(() => unlink(tmpFilePath)).catch(() => undefined);
   }
 
-  uploadPromises[runKey] = new Promise(async (resolve) => {
+  uploadPromises[userRunKey] = new Promise(async (resolve) => {
     try {
       // parquetjs can't write to buffers
       await deleteTmpFile();
       var writer = await parquet.ParquetWriter.openFile(schema, tmpFilePath);
       for (let i = 0; i < answers.length; i++) {
+        // clean up answer objects for parquet
         answers[i].answer = JSON.stringify(answers[i].answer)
+        delete answers[i].report_state;
+        if (typeof answers[i].version === "number") {
+          answers[i].version = "" + answers[i].version;
+        }
+
         await writer.appendRow(answers[i]);
       }
       await writer.close();
@@ -99,21 +118,21 @@ function uploadAnswers(runKey) {
         ContentType: 'application/octet-stream'
       }, function (err) {
         if (err) {
-          console.error(`${runKey}: ${err.toString()}`)
+          console.error(`${userRunKey}: ${err.toString()}`)
         }
       }).promise();
     } catch (err) {
       console.error(err);
     } finally {
       await deleteTmpFile();
-      delete answerHash[runKey];
+      delete answerHash[userRunKey];
     }
 
     // while running keep the upload promises object as small as possible by removing them from the hash
     // this is set to true once all the uploads have been created and the system is waiting for them to complete
     // via Promise.allSettled(...)
     if (!waitingForUploadsToFinish) {
-      delete uploadPromises[runKey];
+      delete uploadPromises[userRunKey];
     }
 
     // always resolve
@@ -124,16 +143,16 @@ function uploadAnswers(runKey) {
 function countBatch(query) {
   query.stream().on('data', (documentSnapshot) => {
     const answer = documentSnapshot.data();
-    answerHash[answer.run_key] = answerHash[answer.run_key] || [];
-    answerHash[answer.run_key].push(answer);
-    if (lastRunKey && (answer.run_key !== lastRunKey)) {
-      uploadAnswers(lastRunKey)
+    const userRunKey = getSyncDocId(answer);
+    answerHash[userRunKey] = answerHash[userRunKey] || [];
+    answerHash[userRunKey].push(answer);
+    if (lastUserRunKey && (userRunKey !== lastUserRunKey)) {
+      uploadAnswers(lastUserRunKey)
     }
-    lastRunKey = answer.run_key;
+    lastUserRunKey = userRunKey;
     lastDoc = documentSnapshot;
     ++count;
     ++batchCount;
-  // }).on('end', () => console.log('Done'));
   }).on('end', onEnd);
 }
 
@@ -142,7 +161,7 @@ function finish() {
   // flag that we are waiting for the uploads to finish - this changes the uploader to not remove upload promises from the hash it uses
   // to track them so that we can then use Promise.allSettled to wait for them to finish
   waitingForUploadsToFinish = true;
-  uploadAnswers(lastRunKey);
+  uploadAnswers(lastUserRunKey);
   const promises = Object.values(uploadPromises);
   console.log(`Waiting for ${promises.length} uploads to finish...`);
   Promise.allSettled(promises).then(() => console.log("Done waiting!"))


### PR DESCRIPTION
This updates the bulk-upload of all answers to support the LTI metadata and new directory structure of the update-answers Firestore function.