### PR TITLE
Support Activity Player runnable urls for imported activities

### DIFF
--- a/query-creator/create-query/steps/firebase.js
+++ b/query-creator/create-query/steps/firebase.js
@@ -13,16 +13,23 @@ exports.getResource = async (runnable, reportServiceSource, demo) => {
 
   const url = `${process.env.REPORT_SERVICE_URL}/resource`
 
-  const queryParams = URL.parse(runnable.url, true).query;
-  if (queryParams && queryParams.activity) {
+  let runnableUrl = runnable.url;
+  const searchParams = new URL(runnableUrl).searchParams;
+
+  if (searchParams) {
     // Activity Player activities that have been imported from LARA have a resource url like
     // https://activity-player.concord.org/?activity=https%3A%2F%2Fauthoring.staging.concord.org%2Fapi%2Fv1%2Factivities%2F20753.json&firebase-app=report-service-dev
     // This changes the above to https://authoring.staging.concord.org/activities/20753
-    runnable.url = queryParams.activity.replace("api/v1/", "").replace(".json", "");
+    const sequenceUrl = searchParams.get("sequence");
+    const activityUrl = searchParams.get("activity");
+    if (sequenceUrl || activityUrl) {
+      runnableUrl = sequenceUrl || activityUrl;
+      runnableUrl = runnableUrl.replace("api/v1/", "").replace(".json", "");
+    }
   }
   const params = {
     source: reportServiceSource,
-    url: runnable.url
+    url: runnableUrl
   }
 
   let response

--- a/query-creator/create-query/steps/firebase.js
+++ b/query-creator/create-query/steps/firebase.js
@@ -11,7 +11,7 @@ exports.getResource = async (runnable, reportServiceSource, demo) => {
     throw new Error(`Unable to find ${runnable.url}`)
   }
 
-  const url = `${process.env.REPORT_SERVICE_URL}/resource`
+  const reportServiceUrl = `${process.env.REPORT_SERVICE_URL}/resource`
 
   let runnableUrl = runnable.url;
   const searchParams = new URL(runnableUrl).searchParams;
@@ -34,7 +34,7 @@ exports.getResource = async (runnable, reportServiceSource, demo) => {
 
   let response
   try {
-    response = await axios.get(url,
+    response = await axios.get(reportServiceUrl,
       {
         headers: {
           "Authorization": `Bearer ${process.env.REPORT_SERVICE_TOKEN}`
@@ -43,13 +43,13 @@ exports.getResource = async (runnable, reportServiceSource, demo) => {
       }
     )
   } catch (e) {
-    throw new Error(`Unable to get resource at ${url} using ${JSON.stringify(params)}. Error: ${e.toString()}. Response: ${e.response ? JSON.stringify(e.response.data) : "no response"}`)
+    throw new Error(`Unable to get resource at ${reportServiceUrl} using ${JSON.stringify(params)}. Error: ${e.toString()}. Response: ${e.response ? JSON.stringify(e.response.data) : "no response"}`)
   }
   const result = response.data
   if (result && result.success && result.resource) {
     return result.resource
   }
-  throw new Error(`Unable to find resource at ${url} using ${JSON.stringify(params)}. Error: ${e.toString()}. Response: ${JSON.stringify(response.data)}`)
+  throw new Error(`Unable to find resource at ${reportServiceUrl} using ${JSON.stringify(params)}. Error: ${e.toString()}. Response: ${JSON.stringify(response.data)}`)
 }
 
 exports.denormalizeResource = (resource) => {

--- a/query-creator/create-query/steps/firebase.js
+++ b/query-creator/create-query/steps/firebase.js
@@ -1,4 +1,5 @@
 const axios = require("axios");
+const URL = require('url');
 
 const sequence120 = require("./firebase-data/sequence-120.json");
 
@@ -11,6 +12,14 @@ exports.getResource = async (runnable, reportServiceSource, demo) => {
   }
 
   const url = `${process.env.REPORT_SERVICE_URL}/resource`
+
+  const queryParams = URL.parse(runnable.url, true).query;
+  if (queryParams && queryParams.activity) {
+    // Activity Player activities that have been imported from LARA have a resource url like
+    // https://activity-player.concord.org/?activity=https%3A%2F%2Fauthoring.staging.concord.org%2Fapi%2Fv1%2Factivities%2F20753.json&firebase-app=report-service-dev
+    // This changes the above to https://authoring.staging.concord.org/activities/20753
+    runnable.url = queryParams.activity.replace("api/v1/", "").replace(".json", "");
+  }
   const params = {
     source: reportServiceSource,
     url: runnable.url


### PR DESCRIPTION
Activity Player activities that have been imported from LARA have a resource url like

https://activity-player.concord.org/?activity=https%3A%2F%2Fauthoring.staging.concord.org%2Fapi%2Fv1%2Factivities%2F20753.json&firebase-app=report-service-dev

this changes the above to

https://authoring.staging.concord.org/activities/20753

so that the resource be properly returned by the report service api.