### PR TITLE
177955279 query creator percent complete

### DIFF
--- a/query-creator/create-query/tests/unit/test-handler.js
+++ b/query-creator/create-query/tests/unit/test-handler.js
@@ -96,8 +96,6 @@ FROM activities,
 
         const untabbedGeneratedSQLresult = generatedSQLresult.replace("\t", "");
         const untabbedExpectedSQLresult = expectedSQLresult.replace("\t", "");
-        console.log(untabbedGeneratedSQLresult);
-        console.log(untabbedExpectedSQLresult);
         expect(untabbedGeneratedSQLresult).to.be.equal(untabbedExpectedSQLresult);
     });
 });


### PR DESCRIPTION
This PR adds the question percent complete to the Athena query generated in `generateSQL`.   The unit test for `generateSQL` has also been expanded to include the percent complete. 

Example query with percent complete:
```
-- activity-activity_20654

WITH activities AS ( SELECT *, cardinality(questions) as num_questions FROM "report-service"."activity_structure" WHERE structure_id = '029ce969-1bb8-4eaf-9f98-e1c6c6277fd9' )

SELECT
  null as remote_endpoint,
  null as num_questions,
  null as num_answers,
  null as percent_complete,
  activities.questions['multiple_choice_12818'].prompt AS multiple_choice_12818_choice,
  activities.questions['multiple_choice_12843'].prompt AS multiple_choice_12843_choice,
  activities.questions['multiple_choice_12845'].prompt AS multiple_choice_12845_choice,
  activities.questions['multiple_choice_12846'].prompt AS multiple_choice_12846_choice,
  activities.questions['multiple_choice_12847'].prompt AS multiple_choice_12847_choice,
  activities.questions['multiple_choice_12848'].prompt AS multiple_choice_12848_choice
FROM activities

UNION ALL

SELECT
  remote_endpoint,
  activities.num_questions,
  cardinality(array_intersect(map_keys(kv1),map_keys(activities.questions))) as num_answers,
  round(100.0 * cardinality(array_intersect(map_keys(kv1),map_keys(activities.questions))) / activities.num_questions, 1) as percent_complete,
  activities.choices['multiple_choice_12818'][json_extract_scalar(kv1['multiple_choice_12818'], '$.choice_ids[0]')].content AS multiple_choice_12818_choice,
  activities.choices['multiple_choice_12843'][json_extract_scalar(kv1['multiple_choice_12843'], '$.choice_ids[0]')].content AS multiple_choice_12843_choice,
  activities.choices['multiple_choice_12845'][json_extract_scalar(kv1['multiple_choice_12845'], '$.choice_ids[0]')].content AS multiple_choice_12845_choice,
  activities.choices['multiple_choice_12846'][json_extract_scalar(kv1['multiple_choice_12846'], '$.choice_ids[0]')].content AS multiple_choice_12846_choice,
  activities.choices['multiple_choice_12847'][json_extract_scalar(kv1['multiple_choice_12847'], '$.choice_ids[0]')].content AS multiple_choice_12847_choice,
  activities.choices['multiple_choice_12848'][json_extract_scalar(kv1['multiple_choice_12848'], '$.choice_ids[0]')].content AS multiple_choice_12848_choice
FROM activities,
  ( SELECT l.run_remote_endpoint remote_endpoint, map_agg(a.question_id, a.answer) kv1, map_agg(a.question_id, a.submitted) submitted
    FROM "report-service"."partitioned_answers" a
    INNER JOIN "report-service"."learners" l
    ON (l.query_id = '029ce969-1bb8-4eaf-9f98-e1c6c6277fd9' AND l.run_remote_endpoint = a.remote_endpoint)
    WHERE a.escaped_url = 'https---authoring-staging-concord-org-activities-20654'
    GROUP BY l.run_remote_endpoint )
```

![image](https://user-images.githubusercontent.com/5126913/118712570-d090ce00-b7d5-11eb-8edd-90e1f8373478.png)
