### PR TITLE
173668043 multiple choice query updates

### DIFF
--- a/query-creator/create-query/steps/aws.js
+++ b/query-creator/create-query/steps/aws.js
@@ -69,24 +69,6 @@ exports.generateSQL = (queryId, runnable, resource, denormalizedResource) => {
   ];
   const escapedUrl = resource.url.replace(/[^a-z0-9]/g, "-");
 
-  const questionIsRequired = (resourceObj, qId) => {
-    let isRequired = false;
-    if (resourceObj.type === "sequence") {
-      resourceObj.children.forEach((activity) => activity.children.forEach((section) => section.children.forEach((page) => page.children.forEach((question) => {
-        if (question.id === qId && question.required) {
-          isRequired = true;
-        }
-      }))));
-    } else if (resourceObj.type === "activity") {
-      resourceObj.children.forEach((section) => section.children.forEach((page) => page.children.forEach((question) => {
-        if (question.id === qId && question.required) {
-          isRequired = true;
-        }
-      })));
-    }
-    return isRequired;
-  }
-
   Object.keys(denormalizedResource.questions).forEach(questionId => {
     const type = questionId.split(/_\d+/).shift();
     switch (type) {
@@ -101,7 +83,7 @@ exports.generateSQL = (queryId, runnable, resource, denormalizedResource) => {
         selectColumns.push(`kv1['${questionId}'] AS ${questionId}_answer`);
         break;
       case "open_response":
-        let isRequired = questionIsRequired(resource, questionId);
+        const isRequired = denormalizedResource.questions[questionId].required;
 
         // add question prompt, include empty column because UNION query requires identical number of fields
         selectColumnPrompts.push(`activities.questions['${questionId}'].prompt AS ${questionId}_text`);
@@ -117,8 +99,15 @@ exports.generateSQL = (queryId, runnable, resource, denormalizedResource) => {
       case "multiple_choice":
         // add question prompt
         selectColumnPrompts.push(`activities.questions['${questionId}'].prompt AS ${questionId}_choice`);
-        const questionHasCorrectAnswer = `cardinality(map_filter(activities.choices['${questionId}'], (k, v) -> v.correct)) > 0`;
-        const answerScore = `IF(${questionHasCorrectAnswer}, IF(activities.choices['${questionId}'][x].correct,' (correct)',' (wrong)'), '')`;
+
+        let questionHasCorrectAnswer = false;
+        for (const choice in denormalizedResource.choices[questionId]) {
+          if (denormalizedResource.choices[questionId][choice].correct) {
+            questionHasCorrectAnswer = true;
+          }
+        }
+
+        const answerScore = questionHasCorrectAnswer ? `IF(activities.choices['${questionId}'][x].correct,' (correct)',' (wrong)')` : `''`;
         const choiceIdsAsArray = `CAST(json_extract(kv1['${questionId}'],'$.choice_ids') AS ARRAY(VARCHAR))`;
         selectColumns.push(`array_join(transform(${choiceIdsAsArray}, x -> CONCAT(activities.choices['${questionId}'][x].content, ${answerScore})),', ') AS ${questionId}_choice`);
         break;

--- a/query-creator/create-query/steps/firebase.js
+++ b/query-creator/create-query/steps/firebase.js
@@ -79,7 +79,8 @@ const denormalizeActivity = (activity, denormalized) => {
     section.children.forEach(page => {
       page.children.forEach(question => {
         denormalized.questions[question.id] = {
-          prompt: question.prompt
+          prompt: question.prompt,
+          required: question.required ? question.required : false
         }
         if (question.type === "multiple_choice") {
           denormalized.choices[question.id] = {}

--- a/query-creator/create-query/tests/unit/test-handler.js
+++ b/query-creator/create-query/tests/unit/test-handler.js
@@ -2,6 +2,7 @@
 
 const app = require('../../app.js');
 const aws = require('../../steps/aws.js');
+const firebase = require('../../steps/firebase.js');
 const chai = require('chai');
 const expect = chai.expect;
 var event, context;
@@ -34,85 +35,25 @@ describe('Query creation', function () {
               children: [
                 { type: "page",
                   children: [
-                    { id: "multiple_choice_00000" },
-                    { id: "multiple_choice_01111" },
-                    { id: "multiple_choice_02222" },
-                    { id: "open_response_11111", required: true },
-                    { id: "open_response_22222", required: false },
-                    { id: "image_question_33333" }
+                    { id: "multiple_choice_00000", type: "multiple_choice", prompt: "mc prompt 1",
+                      choices: [{ content: "a", correct: true, id: 1 }, { content: "b", correct: false, id: 2 }, { content: "c", correct: false, id: 3 }]
+                    },
+                    { id: "multiple_choice_01000", type: "multiple_choice", prompt: "mc prompt 2",
+                      choices: [{ content: "a", correct: false, id: 1 }, { content: "b", correct: false, id: 2 }, { content: "c", correct: false, id: 3 }]
+                    },
+                    { id: "multiple_choice_02000", type: "multiple_choice", prompt: "mc prompt 3",
+                      choices: [{ content: "a", correct: true, id: 1 }, { content: "b", correct: true, id: 2 }, { content: "c", correct: false, id: 3 }]
+                    },
+                    { id: "open_response_11111", type: "open_response", prompt: "open response prompt 1", required: true },
+                    { id: "open_response_22222", type: "open_response", prompt: "open response prompt 2", required: false },
+                    { id: "image_question_33333", type: "image_question", prompt: "image response prompt"}
                   ]
                 }
               ]
             }
           ]
         };
-        const testDenormalizedResource =
-        {
-          questions: {
-            multiple_choice_00000: {
-              prompt: "mc prompt 1"
-            },
-            multiple_choice_01000: {
-              prompt: "mc prompt 2"
-            },
-            multiple_choice_02000: {
-              prompt: "mc prompt 3"
-            },
-            open_response_11111: {
-              prompt: "open response prompt"
-            },
-            open_response_22222: {
-              prompt: "open response prompt 2"
-            },
-            image_question_33333: {
-              prompt: "image response prompt"
-            },
-          },
-          choices: {
-            multiple_choice_00000: {
-              mc_00001: {
-                "content": "a",
-                "correct": true
-              },
-              mc_00002: {
-                "content": "b",
-                "correct": false
-              },
-              mc_00003: {
-                "content": "c",
-                "correct": false
-              }
-            },
-            multiple_choice_01000: {
-              mc_01001: {
-                "content": "a",
-                "correct": false
-              },
-              mc_01002: {
-                "content": "b",
-                "correct": false
-              },
-              mc_01003: {
-                "content": "c",
-                "correct": false
-              }
-            },
-            multiple_choice_02000: {
-              mc_02001: {
-                "content": "a",
-                "correct": true
-              },
-              mc_02002: {
-                "content": "b",
-                "correct": true
-              },
-              mc_02003: {
-                "content": "c",
-                "correct": false
-              }
-            },
-          }
-        };
+        const testDenormalizedResource = firebase.denormalizeResource(testResource);
         const generatedSQLresult = await aws.generateSQL(testQueryId, testRunnable, testResource, testDenormalizedResource);
         const expectedSQLresult = `WITH activities AS ( SELECT *, cardinality(questions) as num_questions FROM "report-service"."activity_structure" WHERE structure_id = '123456789' )
 
@@ -139,9 +80,9 @@ SELECT
   activities.num_questions,
   cardinality(array_intersect(map_keys(kv1),map_keys(activities.questions))) as num_answers,
   round(100.0 * cardinality(array_intersect(map_keys(kv1),map_keys(activities.questions))) / activities.num_questions, 1) as percent_complete,
-  array_join(transform(CAST(json_extract(kv1['multiple_choice_00000'],'$.choice_ids') AS ARRAY(VARCHAR)), x -> CONCAT(activities.choices['multiple_choice_00000'][x].content, IF(cardinality(map_filter(activities.choices['multiple_choice_00000'], (k, v) -> v.correct)) > 0, IF(activities.choices['multiple_choice_00000'][x].correct,' (correct)',' (wrong)'), ''))),', ') AS multiple_choice_00000_choice,
-  array_join(transform(CAST(json_extract(kv1['multiple_choice_01000'],'$.choice_ids') AS ARRAY(VARCHAR)), x -> CONCAT(activities.choices['multiple_choice_01000'][x].content, IF(cardinality(map_filter(activities.choices['multiple_choice_01000'], (k, v) -> v.correct)) > 0, IF(activities.choices['multiple_choice_01000'][x].correct,' (correct)',' (wrong)'), ''))),', ') AS multiple_choice_01000_choice,
-  array_join(transform(CAST(json_extract(kv1['multiple_choice_02000'],'$.choice_ids') AS ARRAY(VARCHAR)), x -> CONCAT(activities.choices['multiple_choice_02000'][x].content, IF(cardinality(map_filter(activities.choices['multiple_choice_02000'], (k, v) -> v.correct)) > 0, IF(activities.choices['multiple_choice_02000'][x].correct,' (correct)',' (wrong)'), ''))),', ') AS multiple_choice_02000_choice,
+  array_join(transform(CAST(json_extract(kv1['multiple_choice_00000'],'$.choice_ids') AS ARRAY(VARCHAR)), x -> CONCAT(activities.choices['multiple_choice_00000'][x].content, IF(activities.choices['multiple_choice_00000'][x].correct,' (correct)',' (wrong)'))),', ') AS multiple_choice_00000_choice,
+  array_join(transform(CAST(json_extract(kv1['multiple_choice_01000'],'$.choice_ids') AS ARRAY(VARCHAR)), x -> CONCAT(activities.choices['multiple_choice_01000'][x].content, ''))),', ') AS multiple_choice_01000_choice,
+  array_join(transform(CAST(json_extract(kv1['multiple_choice_02000'],'$.choice_ids') AS ARRAY(VARCHAR)), x -> CONCAT(activities.choices['multiple_choice_02000'][x].content, IF(activities.choices['multiple_choice_02000'][x].correct,' (correct)',' (wrong)'))),', ') AS multiple_choice_02000_choice,
   kv1['open_response_11111'] AS open_response_11111_text,
   submitted['open_response_11111'] AS open_response_11111_submitted,
   kv1['open_response_22222'] AS open_response_22222_text,

--- a/query-creator/create-query/tests/unit/test-handler.js
+++ b/query-creator/create-query/tests/unit/test-handler.js
@@ -81,7 +81,7 @@ SELECT
   cardinality(array_intersect(map_keys(kv1),map_keys(activities.questions))) as num_answers,
   round(100.0 * cardinality(array_intersect(map_keys(kv1),map_keys(activities.questions))) / activities.num_questions, 1) as percent_complete,
   array_join(transform(CAST(json_extract(kv1['multiple_choice_00000'],'$.choice_ids') AS ARRAY(VARCHAR)), x -> CONCAT(activities.choices['multiple_choice_00000'][x].content, IF(activities.choices['multiple_choice_00000'][x].correct,' (correct)',' (wrong)'))),', ') AS multiple_choice_00000_choice,
-  array_join(transform(CAST(json_extract(kv1['multiple_choice_01000'],'$.choice_ids') AS ARRAY(VARCHAR)), x -> CONCAT(activities.choices['multiple_choice_01000'][x].content, ''))),', ') AS multiple_choice_01000_choice,
+  array_join(transform(CAST(json_extract(kv1['multiple_choice_01000'],'$.choice_ids') AS ARRAY(VARCHAR)), x -> CONCAT(activities.choices['multiple_choice_01000'][x].content, '')),', ') AS multiple_choice_01000_choice,
   array_join(transform(CAST(json_extract(kv1['multiple_choice_02000'],'$.choice_ids') AS ARRAY(VARCHAR)), x -> CONCAT(activities.choices['multiple_choice_02000'][x].content, IF(activities.choices['multiple_choice_02000'][x].correct,' (correct)',' (wrong)'))),', ') AS multiple_choice_02000_choice,
   kv1['open_response_11111'] AS open_response_11111_text,
   submitted['open_response_11111'] AS open_response_11111_submitted,


### PR DESCRIPTION
This PR expands Athena SQL query for multiple choice questions to include:
- show all answers if question supports multiple answers
- show correct/wrong status if question has a valid answer defined

In doing so, the following types of multiple choice questions are now supported:
- multiple choice where user can enter single answer and correct answer is defined
- multiple choice where user can enter single answer and no correct answer is defined
- multiple choice where user can enter multiple answers and correct answer is defined
- multiple choice where user can enter multiple answers and no correct answer is defined

Unit tests have also been expanded to include these new cases. EDIT: I also used the `denormalizedResource` instead of the `resource` inside of `generateSQL` to access information about each question (since we have the `denormalizedResource` with the question structure, it felt redundant to pull that same structure from the `resource`).  I made one change to the `denormalizedResource` to allow this that is only used locally, but we should look and see if this affects anything else adversely.

The query itself is somewhat complicated, so here is an explanation of a few of the parts.  Here is an example of the portion of the query that for a given MC question, returns a user's answers with correct/wrong marked:
```
array_join(transform(CAST(json_extract(kv1['multiple_choice_13100'],'$.choice_ids') AS ARRAY(VARCHAR)), x -> CONCAT(activities.choices['multiple_choice_13100'][x].content, IF(activities.choices['multiple_choice_13100'][x].correct,' (correct)',' (wrong)'))),', ') AS multiple_choice_13100_choice
```

`array_join` will put all of the user answers for a given MC question into a single column.  However, we need to get the answers into an array first.

To do so we get the user answers (the `choice_ids`) in `kv1` as JSON with `json_extract`.  We the cast the JSON to an array (`CAST(...) AS ARRAY`).  We then use array `transform` to create a new array with the complete string for each answer - this includes if the answer is correct or wrong. 

However, not all questions have a correct answer.  To determine if a question has a correct answer we check the choices for a given question in the `denormalizedResource` to determine if any of the choices are marked correct.

If the question does have a correct answer, then we can mark each answer with `(correct)` or `(wrong)` by looking up the user answer in `activities.choices` and checking if it is correct:
```
IF(activities.choices['multiple_choice_13100'][x].correct,' (correct)',' (wrong)')
```

Here is an example of a full query that is generated (EDIT: updated from initial PR):
```
WITH activities AS ( SELECT *, cardinality(questions) as num_questions FROM "report-service"."activity_structure" WHERE structure_id = '888c7a74-35e4-4405-9dd3-bf1d876a577f' )

SELECT
  null as remote_endpoint,
  null as num_questions,
  null as num_answers,
  null as percent_complete,
  activities.questions['multiple_choice_13100'].prompt AS multiple_choice_13100_choice,
  activities.questions['multiple_choice_13103'].prompt AS multiple_choice_13103_choice,
  activities.questions['multiple_choice_13101'].prompt AS multiple_choice_13101_choice,
  activities.questions['multiple_choice_13102'].prompt AS multiple_choice_13102_choice
FROM activities

UNION ALL

SELECT
  remote_endpoint,
  activities.num_questions,
  cardinality(array_intersect(map_keys(kv1),map_keys(activities.questions))) as num_answers,
  round(100.0 * cardinality(array_intersect(map_keys(kv1),map_keys(activities.questions))) / activities.num_questions, 1) as percent_complete,
  array_join(transform(CAST(json_extract(kv1['multiple_choice_13100'],'$.choice_ids') AS ARRAY(VARCHAR)), x -> CONCAT(activities.choices['multiple_choice_13100'][x].content, IF(activities.choices['multiple_choice_13100'][x].correct,' (correct)',' (wrong)'))),', ') AS multiple_choice_13100_choice,
  array_join(transform(CAST(json_extract(kv1['multiple_choice_13103'],'$.choice_ids') AS ARRAY(VARCHAR)), x -> CONCAT(activities.choices['multiple_choice_13103'][x].content, '')),', ') AS multiple_choice_13103_choice,
  array_join(transform(CAST(json_extract(kv1['multiple_choice_13101'],'$.choice_ids') AS ARRAY(VARCHAR)), x -> CONCAT(activities.choices['multiple_choice_13101'][x].content, IF(activities.choices['multiple_choice_13101'][x].correct,' (correct)',' (wrong)'))),', ') AS multiple_choice_13101_choice,
  array_join(transform(CAST(json_extract(kv1['multiple_choice_13102'],'$.choice_ids') AS ARRAY(VARCHAR)), x -> CONCAT(activities.choices['multiple_choice_13102'][x].content, IF(activities.choices['multiple_choice_13102'][x].correct,' (correct)',' (wrong)'))),', ') AS multiple_choice_13102_choice
FROM activities,
  ( SELECT l.run_remote_endpoint remote_endpoint, map_agg(a.question_id, a.answer) kv1, map_agg(a.question_id, a.submitted) submitted
    FROM "report-service"."partitioned_answers" a
    INNER JOIN "report-service"."learners" l
    ON (l.query_id = '888c7a74-35e4-4405-9dd3-bf1d876a577f' AND l.run_remote_endpoint = a.remote_endpoint)
    WHERE a.escaped_url = 'https---authoring-staging-concord-org-activities-21014'
    GROUP BY l.run_remote_endpoint )
```

![image](https://user-images.githubusercontent.com/5126913/119527192-f3226a00-bd34-11eb-9cb8-a57eb02d5d30.png)
