### PR TITLE
Get learners with JWT

### DIFF
--- a/query-creator/README.md
+++ b/query-creator/README.md
@@ -88,6 +88,21 @@ The SAM CLI reads the application template to determine the API's routes and the
             Method: get
 ```
 
+### Testing locally with the portal running locally
+
+When the portal makes its request to the query-creator, it passes a `reportServiceUrl` that points back to the
+API endpoint we can use to make the requests for the learner data.
+
+However, if the portal is running in Docker and the SAM application is as well, it's tricky to get them to talk
+to each other.
+
+While there is probably a much better Docker-ish way to solve this, one hacky solution is to
+
+1. Install [ngrok](https://ngrok.com/), or a similar service to allow you to create a public url for your local servers
+2. Take note of the port that the app is running on in your Docker UI
+3. Publish that port with ngrok and get back a public url
+4. Hardcode `{public_url}/api/v1/report_learners_es/external_report_learners_from_jwt` in the query-creator app as the `reportServiceUrl`
+
 ## Add a resource to your application
 The application template uses AWS Serverless Application Model (AWS SAM) to define application resources. AWS SAM is an extension of AWS CloudFormation with a simpler syntax for configuring common serverless application resources such as functions, triggers, and APIs. For resources not included in [the SAM specification](https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md), you can use standard [AWS CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html) resource types.
 

--- a/query-creator/README.md
+++ b/query-creator/README.md
@@ -167,6 +167,7 @@ Next, you can use AWS Serverless Application Repository to deploy ready to use A
     )
 
     CREATE EXTERNAL TABLE IF NOT EXISTS learners (
+      learner_id: string,
       run_remote_endpoint string,
       class_id int,
       runnable_url string,
@@ -174,7 +175,7 @@ Next, you can use AWS Serverless Application Repository to deploy ready to use A
       class string,
       school string,
       user_id string,
-      perm_forms string,
+      permission_forms string,
       username string,
       student_name string,
       teachers array<struct<user_id: string, name: string, district: string, state: string, email: string>>,

--- a/query-creator/README.md
+++ b/query-creator/README.md
@@ -44,7 +44,7 @@ Or the `QueryCreatorLocalTestUser` credential information can be configured via 
 query-creator$ aws configure
 ```
 
-The following environment variables need to be configured: `JwtHmacSecret`, `OutputBucket`, `ReportServiceToken`, `ReportServiceUrl`. These can be configured system-wide or as default values in the `parameters` section of `template.yml`. For example, `OutputBucket` can be configured as follows:
+The following environment variables need to be configured: `OutputBucket`, `ReportServiceToken`, `ReportServiceUrl`. These can be configured system-wide or as default values in the `parameters` section of `template.yml`. For example, `OutputBucket` can be configured as follows:
 ```
   OutputBucket:
     Type: String
@@ -52,7 +52,7 @@ The following environment variables need to be configured: `JwtHmacSecret`, `Out
     Default: 'concordqa-report-data'
 ```
 
-The environment variable values can be found on the production AWS account under `Cloud formation > Stacks` (for example, the `report-service-query-creator` stack can be used to obtain `JwtHmacSecret`, `OutputBucket`, `ReportServiceToken`, `ReportServiceUrl` values).
+The environment variable values can be found on the production AWS account under `Cloud formation > Stacks` (for example, the `report-service-query-creator` stack can be used to obtain `OutputBucket`, `ReportServiceToken`, `ReportServiceUrl` values).
 
 Build your application with the `sam build` command.
 

--- a/query-creator/create-query/app.js
+++ b/query-creator/create-query/app.js
@@ -22,8 +22,7 @@ exports.lambdaHandler = async (event, context) => {
     const body = request.getBody(event);
     request.validateRequestBody(body);
     const { json, jwt } = body;
-    const { query, learnersApiUrlxx, paginationSize, user } = json;
-    learnersApiUrl = "http://4d9f5154e993.ngrok.io/api/v1/report_learners_es/external_report_learners_from_jwt";
+    const { query, learnersApiUrl, paginationSize, user } = json;
     // ensure create athena workgroup is created for the user and is added to token service
     const workgroup = await aws.ensureWorkgroup(user);
     await tokenService.addWorkgroup(workgroup);

--- a/query-creator/create-query/app.js
+++ b/query-creator/create-query/app.js
@@ -17,14 +17,11 @@ exports.lambdaHandler = async (event, context) => {
       throw new Error("Missing reportServiceSource in the report url");
     }
 
-    // see if we are in demo mode which uses built in request bodies and firebase data
-    const demo = !!params.demo;
-
     // ensure all the environment variables exist
     envVars.validate();
 
-    // get the post body and validate the HMAC and format of the json payload
-    const body = request.getBody(event, demo);
+    // get the post body
+    const body = request.getBody(event);
     const json = request.validateJSON(body);
     const runnables = request.getRunnables(json);
     const user = json.user;
@@ -45,7 +42,7 @@ exports.lambdaHandler = async (event, context) => {
       await aws.uploadLearnerData(queryId, runnable.learners, workgroup);
 
       // get and denormalize the resource (activity or sequence) from Firebase
-      const resource = await firebase.getResource(runnable, reportServiceSource, demo);
+      const resource = await firebase.getResource(runnable, reportServiceSource);
       const denormalizedResource = firebase.denormalizeResource(resource);
 
       // upload the denormalized resource to s3 and tie it to the workgroup

--- a/query-creator/create-query/app.js
+++ b/query-creator/create-query/app.js
@@ -22,12 +22,12 @@ exports.lambdaHandler = async (event, context) => {
     const body = request.getBody(event);
     request.validateRequestBody(body);
     const { json, jwt } = body;
-    const { query, learnersApiUrl, paginationSize, user } = json;
+    const { query, learnersApiUrl, user } = json;
     // ensure create athena workgroup is created for the user and is added to token service
     const workgroup = await aws.ensureWorkgroup(user);
     await tokenService.addWorkgroup(workgroup);
 
-    const queryIdsPerRunnable = await aws.fetchAndUploadLearnerData(jwt, query, learnersApiUrl, paginationSize, workgroup);
+    const queryIdsPerRunnable = await aws.fetchAndUploadLearnerData(jwt, query, learnersApiUrl, workgroup);
 
     const debugSQL = [];
 

--- a/query-creator/create-query/steps/aws.js
+++ b/query-creator/create-query/steps/aws.js
@@ -2,6 +2,8 @@ const AWS = require("aws-sdk");
 const { v4: uuidv4 } = require('uuid');
 const request = require("./request");
 
+const PAGE_SIZE = 1000;
+
 exports.ensureWorkgroup = async (user) => {
   const athena = new AWS.Athena({apiVersion: '2017-05-18'});
   const workgroupName = `${user.id} ${user.email}`.replace(/[^a-z0-9]/g, "-")
@@ -61,10 +63,11 @@ const uploadLearnerData = async (queryId, learners, workgroup) => {
  *
  * @returns queryIdsPerRunnable as {[runnable_url]: queryId}
  */
-exports.fetchAndUploadLearnerData = async (jwt, query, learnersApiUrl, paginationSize, workgroup) => {
+exports.fetchAndUploadLearnerData = async (jwt, query, learnersApiUrl, workgroup) => {
   const queryIdsPerRunnable = {};     // {[runnable_url]: queryId}
   const queryParams = {
     query,
+    page_size: PAGE_SIZE,
     start_from: 0
   };
   let foundAllLearners = false;
@@ -87,7 +90,7 @@ exports.fetchAndUploadLearnerData = async (jwt, query, learnersApiUrl, paginatio
         await uploadLearnerData(queryId, learners, workgroup);
       };
 
-      if (res.json.learners.length < paginationSize) {
+      if (res.json.learners.length < PAGE_SIZE) {
         foundAllLearners = true;
       } else {
         totalLearnersFound += res.json.learners.length;

--- a/query-creator/create-query/steps/env-vars.js
+++ b/query-creator/create-query/steps/env-vars.js
@@ -4,9 +4,6 @@ exports.validate = () => {
     throw new Error(`Missing required ${name} environment variable`);
   }
 
-  if (!process.env.JWT_HMAC_SECRET) {
-    missingVar("JWT_HMAC_SECRET");
-  }
   if (!process.env.OUTPUT_BUCKET) {
     missingVar("OUTPUT_BUCKET");
   }

--- a/query-creator/create-query/steps/firebase.js
+++ b/query-creator/create-query/steps/firebase.js
@@ -1,12 +1,9 @@
 const axios = require("axios");
 const { URL } = require('url');
 
-const sequence120 = require("./firebase-data/sequence-120.json");
-
-exports.getResource = async (runnable, reportServiceSource) => {
+exports.getResource = async (runnableUrl, reportServiceSource) => {
   const reportServiceUrl = `${process.env.REPORT_SERVICE_URL}/resource`
 
-  let runnableUrl = runnable.url;
   const searchParams = new URL(runnableUrl).searchParams;
 
   if (searchParams) {

--- a/query-creator/create-query/steps/firebase.js
+++ b/query-creator/create-query/steps/firebase.js
@@ -3,14 +3,7 @@ const { URL } = require('url');
 
 const sequence120 = require("./firebase-data/sequence-120.json");
 
-exports.getResource = async (runnable, reportServiceSource, demo) => {
-  if (demo) {
-    if (runnable.url === "https://authoring.staging.concord.org/sequences/120") {
-      return Promise.resolve(sequence120);
-    }
-    throw new Error(`Unable to find ${runnable.url}`)
-  }
-
+exports.getResource = async (runnable, reportServiceSource) => {
   const reportServiceUrl = `${process.env.REPORT_SERVICE_URL}/resource`
 
   let runnableUrl = runnable.url;

--- a/query-creator/create-query/steps/request.js
+++ b/query-creator/create-query/steps/request.js
@@ -15,21 +15,6 @@ exports.validateJSON = (body) => {
     throw new Error("Missing json body parameter");
   }
 
-  const signature = body.signature;
-  if (!signature) {
-    throw new Error("Missing signature body parameter");
-  }
-
-  const hmac = crypto.createHmac('sha256', process.env.JWT_HMAC_SECRET);
-  hmac.update(json);
-  const signatureBuffer = new Buffer(signature);
-  const digestBuffer = new Buffer(hmac.digest('hex'));
-
-  if ((signatureBuffer.length !== digestBuffer.length) || !crypto.timingSafeEqual(signatureBuffer, digestBuffer)) {
-    console.log("digestBuffer", digestBuffer.toString())
-    throw new Error("Invalid signature for json parameter");
-  }
-
   try {
     json = JSON.parse(json);
   } catch (e) {

--- a/query-creator/create-query/steps/request.js
+++ b/query-creator/create-query/steps/request.js
@@ -1,48 +1,7 @@
 const crypto = require('crypto');
 const queryString = require('query-string');
 
-exports.getBody = (event, demo) => {
-  if (demo) {
-    return {
-      allowDebug: 1,
-      json: JSON.stringify({
-        "type": "learners",
-        "version": "1.1",
-        "learners": [
-          {
-            "run_remote_endpoint": "https://learn.staging.concord.org/dataservice/external_activity_data/54e0af43-e700-446e-b9db-c64b21c2aeab",
-            "class_id": 33,
-            "runnable_url": "https://authoring.staging.concord.org/sequences/120"
-          },
-          {
-            "run_remote_endpoint": "https://learn.staging.concord.org/dataservice/external_activity_data/2a2945e1-399f-4574-ac5c-cdeec1c408bd",
-            "class_id": 33,
-            "runnable_url": "https://authoring.staging.concord.org/sequences/120"
-          },
-          {
-            "run_remote_endpoint": "https://learn.staging.concord.org/dataservice/external_activity_data/8fbbf080-a785-46c0-b812-d2502715e125",
-            "class_id": 33,
-            "runnable_url": "https://authoring.staging.concord.org/sequences/120"
-          },
-          {
-            "run_remote_endpoint": "https://learn.staging.concord.org/dataservice/external_activity_data/af3b2317-039f-4543-82ff-4e312a1ee0f9",
-            "class_id": 33,
-            "runnable_url": "https://authoring.staging.concord.org/sequences/120"
-          },
-          {
-            "run_remote_endpoint": "https://learn.staging.concord.org/dataservice/external_activity_data/7f7139f9-dced-43f6-93bd-20f5fbf2c642",
-            "class_id": 33,
-            "runnable_url": "https://authoring.staging.concord.org/sequences/120"
-          },
-        ],
-        "user": {
-          "id": "https://example.com/users/1234",
-          "email": "user@example.com"
-        }
-      }),
-      signature: "4d86176489615a0825fbddfead23b6cf4ed75522147ec4e46f0f8d606b7d54d6"
-    }
-  }
+exports.getBody = (event) => {
 
   if (event.body === null) {
     throw new Error("Missing post body in request")

--- a/query-creator/create-query/tests/unit/test-handler.js
+++ b/query-creator/create-query/tests/unit/test-handler.js
@@ -26,7 +26,6 @@ describe('Tests index', function () {
 describe('Query creation', function () {
     it('verifies successful query creation', async () => {
         const testQueryId = "123456789";
-        const testRunnable = null; // isn't used yet
         const testResource = {
           url: "https://authoring.staging.concord.org/activities/000000",
           type: "activity",
@@ -54,7 +53,7 @@ describe('Query creation', function () {
           ]
         };
         const testDenormalizedResource = firebase.denormalizeResource(testResource);
-        const generatedSQLresult = await aws.generateSQL(testQueryId, testRunnable, testResource, testDenormalizedResource);
+        const generatedSQLresult = await aws.generateSQL(testQueryId, testResource, testDenormalizedResource);
         const expectedSQLresult = `WITH activities AS ( SELECT *, cardinality(questions) as num_questions FROM "report-service"."activity_structure" WHERE structure_id = '123456789' )
 
 SELECT

--- a/query-creator/template.yaml
+++ b/query-creator/template.yaml
@@ -4,9 +4,6 @@ Description: >
   query-creator
 
 Parameters:
-  JwtHmacSecret:
-    Type: String
-    Description: Secret to verify request
   OutputBucket:
     Type: String
     Description: Output bucket for Athena queries
@@ -23,7 +20,6 @@ Globals:
     Timeout: 300
     Environment:
       Variables:
-        JWT_HMAC_SECRET: !Ref JwtHmacSecret
         OUTPUT_BUCKET: !Ref OutputBucket
         REPORT_SERVICE_TOKEN: !Ref ReportServiceToken
         REPORT_SERVICE_URL: !Ref ReportServiceUrl


### PR DESCRIPTION
Use JWT to fetch and uploaded paginated learners

This updates the expected request from the portal to be using the JWT query, which then allows us to request learner details from the portal.

The function `aws.fetchAndUploadLearnerData` uses the JWT to request the leaners from the portal, and uploads each batch as it comes. (We no longer try to keep the learners in memory and upload them later, as we want to support requests of up to a million learners.)

Previously, each runnable got a queryId, and we uploaded the learners for that runnable to

`{s3_bucket}/learners/{queryId}/{queryId}.json`

Now, because our learners might be fetched in multiple parts, we upload to

```
{s3_bucket}/learners/{queryId}/{uuid-1}.json
{s3_bucket}/learners/{queryId}/{uuid-2}.json
...
```

We still keep one queryId per runnable.

As a side-effect, we no longer need an JwtHmacSecret. Requests from the portal no longer have the json signed, because they contain a signed JWT instead.