### PR TITLE
Add support for activity player managed interactives in query creation

### DIFF
--- a/query-creator/README.md
+++ b/query-creator/README.md
@@ -136,7 +136,7 @@ Next, you can use AWS Serverless Application Repository to deploy ready to use A
     ```
     CREATE EXTERNAL TABLE IF NOT EXISTS activity_structure (
       choices map<string,map<string,struct<content:string,correct:boolean>>>,
-      questions map<string,struct<prompt:string>>
+      questions map<string,struct<prompt:string,required:boolean,type:string>>
     )
     PARTITIONED BY
     (

--- a/query-creator/create-query/steps/aws.js
+++ b/query-creator/create-query/steps/aws.js
@@ -70,8 +70,9 @@ exports.generateSQL = (queryId, runnable, resource, denormalizedResource) => {
   const escapedUrl = resource.url.replace(/[^a-z0-9]/g, "-");
 
   Object.keys(denormalizedResource.questions).forEach(questionId => {
-    const type = questionId.split(/_\d+/).shift();
+    const type = denormalizedResource.questions[questionId].type;
     const isRequired = denormalizedResource.questions[questionId].required;
+
     switch (type) {
       case "image_question":
         // add question prompt, include empty column because UNION query requires identical number of fields

--- a/query-creator/create-query/steps/firebase.js
+++ b/query-creator/create-query/steps/firebase.js
@@ -80,7 +80,8 @@ const denormalizeActivity = (activity, denormalized) => {
       page.children.forEach(question => {
         denormalized.questions[question.id] = {
           prompt: question.prompt,
-          required: question.required ? question.required : false
+          required: question.required ? question.required : false,
+          type: question.type
         }
         if (question.type === "multiple_choice") {
           denormalized.choices[question.id] = {}


### PR DESCRIPTION
This PR adds the question type to the denormalizedResource which is then used to determine the question type when making the Athena query (rather than using the id).  This allows Activity Player managed interactive questions to work properly in queries.