### PR TITLE
Add secure run script for Mac users

### DIFF
--- a/results-loader/package.json
+++ b/results-loader/package.json
@@ -35,6 +35,8 @@
   },
   "scripts": {
     "start": "webpack serve",
+    "start:secure": "webpack serve --https --cert ~/.localhost-ssl/localhost.pem --key ~/.localhost-ssl/localhost.key",
+    "start:secure:no-certs": "webpack serve --https",
     "build": "npm-run-all lint:build build:webpack",
     "build:webpack": "webpack --mode production",
     "lint": "eslint \"./src/**/*.{js,jsx,ts,tsx}\"",


### PR DESCRIPTION
This is a temporary solution to at least allow Mac devs to run the results-loader using https by running `npm run start:secure` and having the cert/key files in a `.localhost-ssl` folder inside their home directory.  Windows users need to manually change the path to the cert/key files (which works fine for me), but this should, for now, make it easier for devs running on Macs.  Eventually this should be replaced by the platform-independent solution that is on a branch in the `starter-projects`, but as discussed, that solution depends on a release of `webpack-dev-server`.  I think this is a good tweak to get in to make work on the results-loader a little easier.