### PR TITLE
Get athena workgroup resources and resource credentials

### DIFF
--- a/results-loader/package.json
+++ b/results-loader/package.json
@@ -121,6 +121,7 @@
     "webpack-dev-server": "^3.11.2"
   },
   "dependencies": {
+    "@concord-consortium/token-service": "^2.0.0-pre.1",
     "client-oauth2": "^4.3.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/results-loader/src/components/app.scss
+++ b/results-loader/src/components/app.scss
@@ -35,6 +35,10 @@
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
+
+      .sub-info {
+        margin-left: 20px;
+      }
     }
   }
 }

--- a/results-loader/src/components/app.tsx
+++ b/results-loader/src/components/app.tsx
@@ -1,8 +1,11 @@
 import React, { useState, useEffect } from "react";
+import { Resource, ResourceType, Credentials } from "@concord-consortium/token-service";
 import { Header } from "./header";
-import { readPortalAccessToken, getFirebaseJwt } from "../utils/results-utils";
+import { readPortalAccessToken, getFirebaseJwt, listResources, getCredentials } from "../utils/results-utils";
 
 import "./app.scss";
+
+type ResourceMap = {[key: string]: Resource};
 
 export const App = () => {
   // const tokenServiceEnv = "staging";
@@ -16,6 +19,13 @@ export const App = () => {
   const firebaseAppName = "token-service";
   const [firebaseJwt, setFirebaseJwt] = useState("");
 
+  const tokenServiceEnv = "staging";
+  const [resourcesStatus, setResourcesStatus] = useState("nothing happening...");
+  const [resources, setResources] = useState({} as ResourceMap);
+  const [currentResource, setCurrentResource] = useState<Resource | undefined>();
+  const resourceType = "athenaWorkgroup";
+
+  const [credentials, setCredentials] = useState<Credentials | undefined>();
 
   useEffect(() => {
     const portalAccessTokenReturn = readPortalAccessToken(portalUrl, oauthClientName);
@@ -32,6 +42,45 @@ export const App = () => {
     }
   }, [portalAccessToken]);
 
+  useEffect(() => {
+    const handleListMyResources = async () => {
+      // Clear existing resources
+      setResources({} as ResourceMap);
+      setResourcesStatus("loading...");
+      const resourceList = await listResources(firebaseJwt, true, tokenServiceEnv, resourceType as ResourceType);
+      if(resourceList.length === 0) {
+        setResourcesStatus("no resources found");
+      } else {
+        setResourcesStatus("loaded");
+        setResources(resourceList.reduce((map: ResourceMap, resource: Resource) => {
+          map[resource.id] = resource;
+          return map;
+        }, {} as ResourceMap));
+        setCurrentResource(resourceList[0]);
+      }
+    };
+
+    if (portalAccessToken && firebaseJwt) {
+      handleListMyResources();
+    }
+  }, [portalAccessToken, firebaseJwt]);
+
+  useEffect(() => {
+    const handleGetCredentials = async () => {
+      if (!currentResource) return;
+      const _credentials = await getCredentials({
+        resource: currentResource,
+        firebaseJwt,
+        tokenServiceEnv
+      });
+      setCredentials(_credentials);
+    };
+
+    if (portalAccessToken && firebaseJwt && currentResource) {
+      handleGetCredentials();
+    }
+  }, [portalAccessToken, firebaseJwt, currentResource]);
+
   return (
     <div className="app">
       <Header />
@@ -45,6 +94,24 @@ export const App = () => {
                 : <div className="info">{`Firebase JWT: ${firebaseJwt.slice(0, 40)}...`}</div>
               }
             </>
+        }
+        { Object.keys(resources).length > 0 &&
+          <div className="info">{Object.keys(resources).length} Athena workgroup resources found </div>
+        }
+        { currentResource
+          ? <div className="info">Athena workgroup current resource:
+              <div className="sub-info">id: {currentResource.id}</div>
+              <div className="sub-info">name: {currentResource.name}</div>
+              <div className="sub-info">description: {currentResource.description}</div>
+            </div>
+          : <div>{resourcesStatus}</div>
+        }
+        { credentials &&
+          <div className="info">Athena workgroup current resource credentials:
+            <div className="sub-info">access key id: {credentials.accessKeyId}</div>
+            <div className="sub-info">secret access key: {credentials.secretAccessKey}</div>
+            <div className="sub-info">session token: ${credentials.sessionToken.slice(0, 40)}...</div>
+          </div>
         }
       </div>
     </div>

--- a/results-loader/src/utils/results-utils.ts
+++ b/results-loader/src/utils/results-utils.ts
@@ -52,12 +52,9 @@ interface IGetCredentials {
 }
 export const getCredentials = async ({resource, firebaseJwt,
   tokenServiceEnv}: IGetCredentials): Promise<Credentials> => {
-
   // The jwt will be ignored if there is a readWriteToken on the resource
   const client = new TokenServiceClient({ env: tokenServiceEnv, jwt: firebaseJwt });
-  const readWriteToken = client.getReadWriteToken(resource) || "";
-
-  return readWriteToken ? await client.getCredentials(resource.id, readWriteToken) :  await client.getCredentials(resource.id);
+  return client.getCredentials(resource.id);
 };
 
 export const listResources = async (firebaseJwt: string, amOwner: boolean,

--- a/results-loader/src/utils/results-utils.ts
+++ b/results-loader/src/utils/results-utils.ts
@@ -54,11 +54,11 @@ export const getCredentials = async ({resource, firebaseJwt,
   tokenServiceEnv}: IGetCredentials): Promise<Credentials> => {
 
   // The jwt will be ignored if there is a readWriteToken on the resource
-  const client = new TokenServiceClient({ env: tokenServiceEnv, jwt: firebaseJwt })
+  const client = new TokenServiceClient({ env: tokenServiceEnv, jwt: firebaseJwt });
   const readWriteToken = client.getReadWriteToken(resource) || "";
 
   return readWriteToken ? await client.getCredentials(resource.id, readWriteToken) :  await client.getCredentials(resource.id);
-}
+};
 
 export const listResources = async (firebaseJwt: string, amOwner: boolean,
   tokenServiceEnv: EnvironmentName, resourceType: ResourceType) => {


### PR DESCRIPTION
This PR gets the Athena workgroup resources based on the portal access token and firebase JWT.  It also gets the resource credentials for the first resource in the resource list.  Changes include:
- add `@concord-consortium/token-service`
- get list of athena workgroup resources and set 0th resource as the current resource
- display information about current resource in app
- get the credentials for the current resource and display the credential information in the app
- improve and unify the status messages at each step.  This makes it easier to follow the render code and easier to refactor chunks out into components if needed.

Note that when we call `listResources`, I'm setting the `tool` property to `example-app`.  Obviously this is wrong and need to be some string that is used by query-creator.  However, for now this makes debugging a little easier as these changes can be used in sync with resources created by the example-app.  I'm not entirely sure what the final value should be.