### PR TITLE
Update SQL to include learner metadata

### DIFF
--- a/query-creator/README.md
+++ b/query-creator/README.md
@@ -179,6 +179,8 @@ Next, you can use AWS Serverless Application Repository to deploy ready to use A
 ## AWS Glue/Athena Setup
 
 1. Create a `report-service` database in AWS Glue.
+2. If running on production, replace all instances of `concordqa-report-data` below with `concord-report-data`, or
+   any other location as appropriate
 2. In Athena with the `report-service` database selected run the following:
 
     ```
@@ -191,12 +193,12 @@ Next, you can use AWS Serverless Application Repository to deploy ready to use A
         structure_id STRING
     )
     ROW FORMAT SERDE 'org.openx.data.jsonserde.JsonSerDe'
-    LOCATION "s3://concord-report-data/activity-structure/"
+    LOCATION "s3://concordqa-report-data/activity-structure/"
     TBLPROPERTIES
     (
         "projection.enabled" = "true",
         "projection.structure_id.type" = "injected",
-        "storage.location.template" = "s3://concord-report-data/activity-structure/${structure_id}"
+        "storage.location.template" = "s3://concordqa-report-data/activity-structure/${structure_id}"
     )
 
     CREATE EXTERNAL TABLE IF NOT EXISTS learners (
@@ -219,12 +221,12 @@ Next, you can use AWS Serverless Application Repository to deploy ready to use A
         query_id STRING
     )
     ROW FORMAT SERDE 'org.openx.data.jsonserde.JsonSerDe'
-    LOCATION "s3://concord-report-data/learners/"
+    LOCATION "s3://concordqa-report-data/learners/"
     TBLPROPERTIES
     (
         "projection.enabled" = "true",
         "projection.query_id.type" = "injected",
-        "storage.location.template" = "s3://concord-report-data/learners/${query_id}"
+        "storage.location.template" = "s3://concordqa-report-data/learners/${query_id}"
     )
 
     CREATE EXTERNAL TABLE IF NOT EXISTS partitioned_answers (
@@ -253,11 +255,11 @@ Next, you can use AWS Serverless Application Repository to deploy ready to use A
         escaped_url STRING
     )
     ROW FORMAT SERDE 'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe'
-    LOCATION "s3://concord-report-data/partitioned-answers/"
+    LOCATION "s3://concordqa-report-data/partitioned-answers/"
     TBLPROPERTIES
     (
         "projection.enabled" = "true",
         "projection.escaped_url.type" = "injected",
-        "storage.location.template" = "s3://concord-report-data/partitioned-answers/${escaped_url}"
+        "storage.location.template" = "s3://concordqa-report-data/partitioned-answers/${escaped_url}"
     )
     ```

--- a/query-creator/README.md
+++ b/query-creator/README.md
@@ -214,7 +214,7 @@ Next, you can use AWS Serverless Application Repository to deploy ready to use A
       username string,
       student_name string,
       teachers array<struct<user_id: string, name: string, district: string, state: string, email: string>>,
-      last_run timestamp
+      last_run string
     )
     PARTITIONED BY
     (

--- a/query-creator/README.md
+++ b/query-creator/README.md
@@ -200,7 +200,7 @@ Next, you can use AWS Serverless Application Repository to deploy ready to use A
     )
 
     CREATE EXTERNAL TABLE IF NOT EXISTS learners (
-      learner_id: string,
+      learner_id string,
       run_remote_endpoint string,
       class_id int,
       runnable_url string,

--- a/query-creator/create-query/steps/aws.js
+++ b/query-creator/create-query/steps/aws.js
@@ -203,11 +203,22 @@ exports.generateSQL = (queryId, resource, denormalizedResource) => {
   const nullAsMetadata = metadataColumns.map(md => `  null as ${md}`).join(",\n") + ",\n"
   const assignMetadata = metadataColumns.map(md => `arbitrary(l.${md}) ${md}`).join(",")
 
+  const teacherMetadataColumns = [
+    ["teacher_user_ids", "user_id"],
+    ["teacher_names", "name"],
+    ["teacher_districts", "district"],
+    ["teacher_states", "state"],
+    ["teacher_emails", "email"]
+  ]
+  const teacherMetadataColumnsLabels = teacherMetadataColumns.map(tmd => tmd[0])
+  const nullAsTeacherMetadata = teacherMetadataColumnsLabels.map(md => `  null as ${md}`).join(",\n") + ",\n"
+  const assignTeacherMetaData = teacherMetadataColumns.map(tmd => `array_join(transform(teachers, teacher -> teacher.${tmd[1]}), ',') as ${tmd[0]}`)
+  const assignTeacherVar = "arbitrary(l.teachers) teachers"
 
   return `WITH activities AS ( SELECT *, cardinality(questions) as num_questions FROM "report-service"."activity_structure" WHERE structure_id = '${queryId}' )
 
 SELECT
-  ${[`null as remote_endpoint,\n${nullAsMetadata}  null as num_questions,\n  null as num_answers,\n  null as percent_complete`].concat(selectColumnPrompts).join(",\n  ")}
+  ${[`null as remote_endpoint,\n${nullAsMetadata}${nullAsTeacherMetadata}  null as num_questions,\n  null as num_answers,\n  null as percent_complete`].concat(selectColumnPrompts).join(",\n  ")}
 FROM activities
 
 UNION ALL
@@ -216,11 +227,12 @@ SELECT
   ${[
     "remote_endpoint",
     ...metadataColumns,
+    ...assignTeacherMetaData,
     ...completionColumns,
     ...selectColumns
     ].join(",\n  ")}
 FROM activities,
-  ( SELECT l.run_remote_endpoint remote_endpoint, ${assignMetadata}map_agg(a.question_id, a.answer) kv1, map_agg(a.question_id, a.submitted) submitted
+  ( SELECT l.run_remote_endpoint remote_endpoint, ${assignMetadata}, ${assignTeacherVar}, map_agg(a.question_id, a.answer) kv1, map_agg(a.question_id, a.submitted) submitted
     FROM "report-service"."partitioned_answers" a
     INNER JOIN "report-service"."learners" l
     ON (l.query_id = '${queryId}' AND l.run_remote_endpoint = a.remote_endpoint)

--- a/query-creator/create-query/steps/aws.js
+++ b/query-creator/create-query/steps/aws.js
@@ -198,6 +198,7 @@ exports.generateSQL = (queryId, resource, denormalizedResource) => {
     "class",
     "class_id",
     "permission_forms",
+    "last_run",
   ]
   const nullAsMetadata = metadataColumns.map(md => `  null as ${md}`).join(",\n") + ",\n"
   const assignMetadata = metadataColumns.map(md => `arbitrary(l.${md}) ${md}`).join(",")

--- a/query-creator/create-query/tests/unit/test-handler.js
+++ b/query-creator/create-query/tests/unit/test-handler.js
@@ -67,6 +67,22 @@ describe('Query creation', function () {
 
 SELECT
   null as remote_endpoint,
+  null as runnable_url,
+  null as learner_id,
+  null as student_id,
+  null as user_id,
+  null as student_name,
+  null as username,
+  null as school,
+  null as class,
+  null as class_id,
+  null as permission_forms,
+  null as last_run,
+  null as teacher_user_ids,
+  null as teacher_names,
+  null as teacher_districts,
+  null as teacher_states,
+  null as teacher_emails,
   null as num_questions,
   null as num_answers,
   null as percent_complete,
@@ -96,6 +112,22 @@ UNION ALL
 
 SELECT
   remote_endpoint,
+  runnable_url,
+  learner_id,
+  student_id,
+  user_id,
+  student_name,
+  username,
+  school,
+  class,
+  class_id,
+  permission_forms,
+  last_run,
+  array_join(transform(teachers, teacher -> teacher.user_id), ',') as teacher_user_ids,
+  array_join(transform(teachers, teacher -> teacher.name), ',') as teacher_names,
+  array_join(transform(teachers, teacher -> teacher.district), ',') as teacher_districts,
+  array_join(transform(teachers, teacher -> teacher.state), ',') as teacher_states,
+  array_join(transform(teachers, teacher -> teacher.email), ',') as teacher_emails,
   activities.num_questions,
   cardinality(array_intersect(map_keys(kv1),map_keys(activities.questions))) as num_answers,
   round(100.0 * cardinality(array_intersect(map_keys(kv1),map_keys(activities.questions))) / activities.num_questions, 1) as percent_complete,
@@ -120,7 +152,7 @@ SELECT
   json_extract_scalar(kv1['managed_interactive_77777'], '$.text') AS managed_interactive_77777_text,
   kv1['managed_interactive_77777'] AS managed_interactive_77777_answer
 FROM activities,
-  ( SELECT l.run_remote_endpoint remote_endpoint, map_agg(a.question_id, a.answer) kv1, map_agg(a.question_id, a.submitted) submitted
+  ( SELECT l.run_remote_endpoint remote_endpoint, arbitrary(l.runnable_url) runnable_url,arbitrary(l.learner_id) learner_id,arbitrary(l.student_id) student_id,arbitrary(l.user_id) user_id,arbitrary(l.student_name) student_name,arbitrary(l.username) username,arbitrary(l.school) school,arbitrary(l.class) class,arbitrary(l.class_id) class_id,arbitrary(l.permission_forms) permission_forms,arbitrary(l.last_run) last_run, arbitrary(l.teachers) teachers, map_agg(a.question_id, a.answer) kv1, map_agg(a.question_id, a.submitted) submitted
     FROM "report-service"."partitioned_answers" a
     INNER JOIN "report-service"."learners" l
     ON (l.query_id = '123456789' AND l.run_remote_endpoint = a.remote_endpoint)


### PR DESCRIPTION
This adds the following fields to the table returned by the SQL query:

```
runnable_url,
learner_id,
student_id,
user_id,
student_name,
username,
school,
class,
class_id,
permission_forms,
last_run,
teacher_user_ids,
teacher_names,
teacher_districts,
teacher_states,
teacher_emails,
```

Here is an example of a query produced by these changes, which can be run in Athena on staging:

```
-- activity-activity_20654

WITH activities AS ( SELECT *, cardinality(questions) as num_questions FROM "report-service"."activity_structure" WHERE structure_id = 'e49ac023-e318-49ff-9260-5c4b1c461ca7' )

SELECT
  null as remote_endpoint,
  null as runnable_url,
  null as learner_id,
  null as student_id,
  null as user_id,
  null as student_name,
  null as username,
  null as school,
  null as class,
  null as class_id,
  null as permission_forms,
  null as last_run,
  null as teacher_user_ids,
  null as teacher_names,
  null as teacher_districts,
  null as teacher_states,
  null as teacher_emails,
  null as num_questions,
  null as num_answers,
  null as percent_complete,
  activities.questions['multiple_choice_12818'].prompt AS multiple_choice_12818_choice,
  activities.questions['multiple_choice_12843'].prompt AS multiple_choice_12843_choice,
  activities.questions['multiple_choice_12845'].prompt AS multiple_choice_12845_choice,
  activities.questions['multiple_choice_12846'].prompt AS multiple_choice_12846_choice,
  activities.questions['multiple_choice_12847'].prompt AS multiple_choice_12847_choice,
  null AS multiple_choice_12847_submitted,
  activities.questions['multiple_choice_12848'].prompt AS multiple_choice_12848_choice,
  null AS multiple_choice_12848_submitted,
  activities.questions['managed_interactive_155'].prompt AS managed_interactive_155_choice
FROM activities

UNION ALL

SELECT
  remote_endpoint,
  runnable_url,
  learner_id,
  student_id,
  user_id,
  student_name,
  username,
  school,
  class,
  class_id,
  permission_forms,
  last_run,
  array_join(transform(teachers, teacher -> teacher.user_id), ',') as teacher_user_ids,
  array_join(transform(teachers, teacher -> teacher.name), ',') as teacher_names,
  array_join(transform(teachers, teacher -> teacher.district), ',') as teacher_districts,
  array_join(transform(teachers, teacher -> teacher.state), ',') as teacher_states,
  array_join(transform(teachers, teacher -> teacher.email), ',') as teacher_emails,
  activities.num_questions,
  cardinality(array_intersect(map_keys(kv1),map_keys(activities.questions))) as num_answers,
  round(100.0 * cardinality(array_intersect(map_keys(kv1),map_keys(activities.questions))) / activities.num_questions, 1) as percent_complete,
  array_join(transform(CAST(json_extract(kv1['multiple_choice_12818'],'$.choice_ids') AS ARRAY(VARCHAR)), x -> CONCAT(activities.choices['multiple_choice_12818'][x].content, IF(activities.choices['multiple_choice_12818'][x].correct,' (correct)',' (wrong)'))),', ') AS multiple_choice_12818_choice,
  array_join(transform(CAST(json_extract(kv1['multiple_choice_12843'],'$.choice_ids') AS ARRAY(VARCHAR)), x -> CONCAT(activities.choices['multiple_choice_12843'][x].content, '')),', ') AS multiple_choice_12843_choice,
  array_join(transform(CAST(json_extract(kv1['multiple_choice_12845'],'$.choice_ids') AS ARRAY(VARCHAR)), x -> CONCAT(activities.choices['multiple_choice_12845'][x].content, '')),', ') AS multiple_choice_12845_choice,
  array_join(transform(CAST(json_extract(kv1['multiple_choice_12846'],'$.choice_ids') AS ARRAY(VARCHAR)), x -> CONCAT(activities.choices['multiple_choice_12846'][x].content, '')),', ') AS multiple_choice_12846_choice,
  array_join(transform(CAST(json_extract(kv1['multiple_choice_12847'],'$.choice_ids') AS ARRAY(VARCHAR)), x -> CONCAT(activities.choices['multiple_choice_12847'][x].content, '')),', ') AS multiple_choice_12847_choice,
  submitted['multiple_choice_12847'] AS multiple_choice_12847_submitted,
  array_join(transform(CAST(json_extract(kv1['multiple_choice_12848'],'$.choice_ids') AS ARRAY(VARCHAR)), x -> CONCAT(activities.choices['multiple_choice_12848'][x].content, '')),', ') AS multiple_choice_12848_choice,
  submitted['multiple_choice_12848'] AS multiple_choice_12848_submitted,
  array_join(transform(CAST(json_extract(kv1['managed_interactive_155'],'$.choice_ids') AS ARRAY(VARCHAR)), x -> CONCAT(activities.choices['managed_interactive_155'][x].content, '')),', ') AS managed_interactive_155_choice
FROM activities,
  ( SELECT l.run_remote_endpoint remote_endpoint, arbitrary(l.runnable_url) runnable_url,arbitrary(l.learner_id) learner_id,arbitrary(l.student_id) student_id,arbitrary(l.user_id) user_id,arbitrary(l.student_name) student_name,arbitrary(l.username) username,arbitrary(l.school) school,arbitrary(l.class) class,arbitrary(l.class_id) class_id,arbitrary(l.permission_forms) permission_forms,arbitrary(l.last_run) last_run, arbitrary(l.teachers) teachers, map_agg(a.question_id, a.answer) kv1, map_agg(a.question_id, a.submitted) submitted
    FROM "report-service"."partitioned_answers" a
    INNER JOIN "report-service"."learners" l
    ON (l.query_id = 'e49ac023-e318-49ff-9260-5c4b1c461ca7' AND l.run_remote_endpoint = a.remote_endpoint)
    WHERE a.escaped_url = 'https---authoring-staging-concord-org-activities-20654'
    GROUP BY l.run_remote_endpoint )
```

The new values in the SQL can be seen in the diff of the spec test (fc9c926db).