### PR TITLE
Get query execution list and query execution, display to user

### DIFF
--- a/results-loader/package-lock.json
+++ b/results-loader/package-lock.json
@@ -1314,6 +1314,11 @@
         "minimist": "^1.2.0"
       }
     },
+    "@concord-consortium/token-service": {
+      "version": "2.0.0-pre.1",
+      "resolved": "https://registry.npmjs.org/@concord-consortium/token-service/-/token-service-2.0.0-pre.1.tgz",
+      "integrity": "sha512-LerED44VUnCF9vxCarJZC60h9xgw8QqvYsvNIvTHYcg5zPlpVls1FPVk21eRvseYBKdkg/8wK6/wuXt4fm7PfA=="
+    },
     "@cypress/browserify-preprocessor": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@cypress/browserify-preprocessor/-/browserify-preprocessor-3.0.1.tgz",
@@ -4266,6 +4271,68 @@
         }
       }
     },
+    "aws-sdk": {
+      "version": "2.925.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.925.0.tgz",
+      "integrity": "sha512-dHXngzuSTZvIFWizWbU+ceZTAKmgodzEIi/AWbB+z0THKfxD3Iz/CJ7kZ7a9QyZv7X082L68vv3siMhXBMoTLA==",
+      "requires": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "4.9.2",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+          "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
+          }
+        },
+        "events": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+          "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+        },
+        "ieee754": {
+          "version": "1.1.13",
+          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+          "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+        },
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        },
+        "sax": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+          "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+        },
+        "url": {
+          "version": "0.10.3",
+          "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+          "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+          "requires": {
+            "punycode": "1.3.2",
+            "querystring": "0.2.0"
+          }
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        }
+      }
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -4724,8 +4791,7 @@
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "batch": {
       "version": "0.6.1",
@@ -10469,8 +10535,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -12243,6 +12308,11 @@
           }
         }
       }
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
     "joi": {
       "version": "17.4.0",
@@ -15212,8 +15282,7 @@
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "dev": true
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "querystring-es3": {
       "version": "0.2.1",
@@ -16116,8 +16185,7 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "saxes": {
       "version": "5.0.1",
@@ -19295,6 +19363,20 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xmlchars": {
       "version": "2.2.0",

--- a/results-loader/package.json
+++ b/results-loader/package.json
@@ -37,6 +37,7 @@
     "start": "webpack serve",
     "start:secure": "webpack serve --https --cert ~/.localhost-ssl/localhost.pem --key ~/.localhost-ssl/localhost.key",
     "start:secure:no-certs": "webpack serve --https",
+    "start:secure-windows": "webpack serve --https --inline --hot --content-base dist/ --cert ./.localhost-ssl/localhost.pem --key ./.localhost-ssl/localhost.key",
     "build": "npm-run-all lint:build build:webpack",
     "build:webpack": "webpack --mode production",
     "lint": "eslint \"./src/**/*.{js,jsx,ts,tsx}\"",
@@ -122,6 +123,7 @@
   },
   "dependencies": {
     "@concord-consortium/token-service": "^2.0.0-pre.1",
+    "aws-sdk": "^2.924.0",
     "client-oauth2": "^4.3.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/results-loader/src/components/query-item.scss
+++ b/results-loader/src/components/query-item.scss
@@ -1,0 +1,27 @@
+@import "./vars.scss";
+
+.query-item {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  background-color: #efefef;
+  border: solid 1px darkgray;
+  border-radius: 2px;
+  padding: 3px 10px;
+
+  &:nth-child(even) {
+    background-color: white;
+    border-top: none;
+  }
+
+  .item-info {
+    margin: 5px 10px 5px 0;
+  }
+
+  button {
+    flex-grow: 0;
+    flex-shrink: 0;
+    width: 125px;
+  }
+}

--- a/results-loader/src/components/query-item.tsx
+++ b/results-loader/src/components/query-item.tsx
@@ -1,0 +1,51 @@
+import React, { useState, useEffect } from "react";
+import * as AWS from "aws-sdk";
+import { Resource, Credentials, AthenaResource } from "@concord-consortium/token-service";
+
+import "./query-item.scss";
+
+interface IProps {
+  queryExecutionId: string;
+  credentials: Credentials;
+  currentResource: Resource;
+}
+
+export const QueryItem: React.FC<IProps> = (props) => {
+  const { queryExecutionId, credentials, currentResource } = props;
+  const [queryExecutionStatus, setQueryExecutionStatus] = useState("Loading query information...");
+  const [submissionDateTime, setSubmissionDateTime] = useState("");
+  const [outputLocation, setOutputLocation] = useState("");
+
+  useEffect(() => {
+    const handleGetQueryExecution = async () => {
+      const { region } = currentResource as AthenaResource;
+      const { accessKeyId, secretAccessKey, sessionToken } = credentials;
+      const athena = new AWS.Athena({ region, accessKeyId, secretAccessKey, sessionToken });
+
+      const results = await athena.getQueryExecution({
+        QueryExecutionId: queryExecutionId
+      }).promise();
+
+      setQueryExecutionStatus("");
+      setSubmissionDateTime(results.QueryExecution?.Status?.SubmissionDateTime?.toUTCString() || "error");
+      setOutputLocation(results.QueryExecution?.ResultConfiguration?.OutputLocation || "error");
+    };
+
+    handleGetQueryExecution();
+  }, [credentials, currentResource, queryExecutionId]);
+
+  return (
+    <div className="query-item">
+      { queryExecutionStatus
+        ? queryExecutionStatus
+        : <>
+            <div>
+              <div className="item-info">{`Creation date: ${submissionDateTime}`}</div>
+              <div className="item-info">{`Output location: ${outputLocation}`}</div>
+            </div>
+            <button>Generate Download Link</button>
+          </>
+      }
+    </div>
+  );
+};


### PR DESCRIPTION
This PR gets the list of queries for the current workgroup and display information about these queries to the user in list form.  Changes include:
- request list of query execution ids for current workgroup
- for each query execution id, get query execution information
- using the query execution information, display the query date, query URI (won't be needed long-term, but is useful to show uniqueness for now), and present a button for downloading CSV (nothing is implemented here yet - that will be next).  