### PR TITLE
Report name update, Restore QueryItem component

### DIFF
--- a/researcher-reports/README.md
+++ b/researcher-reports/README.md
@@ -1,4 +1,4 @@
-# Results Loader
+# Researcher Reports
 
 ## Development
 
@@ -66,6 +66,6 @@ Inside of your `package.json` file:
 
 ## License
 
-Results Loader are Copyright 2021 (c) by the Concord Consortium and is distributed under the [MIT license](http://www.opensource.org/licenses/MIT).
+Researcher Reports are Copyright 2021 (c) by the Concord Consortium and is distributed under the [MIT license](http://www.opensource.org/licenses/MIT).
 
 See license.md for the complete license text.

--- a/researcher-reports/package.json
+++ b/researcher-reports/package.json
@@ -1,7 +1,7 @@
 {
   "name": "researcher-reports",
   "version": "0.0.1",
-  "description": "Concord Consortium results loader",
+  "description": "Concord Consortium researcher reports",
   "main": "index.js",
   "jest": {
     "testURL": "https://researcher-reports.unexisting.url.com",

--- a/researcher-reports/src/components/header.tsx
+++ b/researcher-reports/src/components/header.tsx
@@ -7,7 +7,7 @@ export const Header: React.FC = () => {
   return (
     <div className="header">
       <img src={Icon}/>
-      Report Results Loader
+      Researcher Reports
     </div>
   );
 };

--- a/researcher-reports/src/components/query-item.scss
+++ b/researcher-reports/src/components/query-item.scss
@@ -1,0 +1,27 @@
+@import "./vars.scss";
+
+.query-item {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  background-color: #efefef;
+  border: solid 1px darkgray;
+  border-radius: 2px;
+  padding: 3px 10px;
+
+  &:nth-child(even) {
+    background-color: white;
+    border-top: none;
+  }
+
+  .item-info {
+    margin: 5px 10px 5px 0;
+  }
+
+  button {
+    flex-grow: 0;
+    flex-shrink: 0;
+    width: 125px;
+  }
+}

--- a/researcher-reports/src/components/query-item.tsx
+++ b/researcher-reports/src/components/query-item.tsx
@@ -1,0 +1,51 @@
+import React, { useState, useEffect } from "react";
+import * as AWS from "aws-sdk";
+import { Resource, Credentials, AthenaResource } from "@concord-consortium/token-service";
+
+import "./query-item.scss";
+
+interface IProps {
+  queryExecutionId: string;
+  credentials: Credentials;
+  currentResource: Resource;
+}
+
+export const QueryItem: React.FC<IProps> = (props) => {
+  const { queryExecutionId, credentials, currentResource } = props;
+  const [queryExecutionStatus, setQueryExecutionStatus] = useState("Loading query information...");
+  const [submissionDateTime, setSubmissionDateTime] = useState("");
+  const [outputLocation, setOutputLocation] = useState("");
+
+  useEffect(() => {
+    const handleGetQueryExecution = async () => {
+      const { region } = currentResource as AthenaResource;
+      const { accessKeyId, secretAccessKey, sessionToken } = credentials;
+      const athena = new AWS.Athena({ region, accessKeyId, secretAccessKey, sessionToken });
+
+      const results = await athena.getQueryExecution({
+        QueryExecutionId: queryExecutionId
+      }).promise();
+
+      setQueryExecutionStatus("");
+      setSubmissionDateTime(results.QueryExecution?.Status?.SubmissionDateTime?.toUTCString() || "error");
+      setOutputLocation(results.QueryExecution?.ResultConfiguration?.OutputLocation || "error");
+    };
+
+    handleGetQueryExecution();
+  }, [credentials, currentResource, queryExecutionId]);
+
+  return (
+    <div className="query-item">
+      { queryExecutionStatus
+        ? queryExecutionStatus
+        : <>
+            <div>
+              <div className="item-info">{`Creation date: ${submissionDateTime}`}</div>
+              <div className="item-info">{`Output location: ${outputLocation}`}</div>
+            </div>
+            <button>Generate Download Link</button>
+          </>
+      }
+    </div>
+  );
+};

--- a/researcher-reports/src/index.html
+++ b/researcher-reports/src/index.html
@@ -2,8 +2,8 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <title>Results Loader</title>
-    <meta name="description" content="Results Loader">
+    <title>Researcher Reports</title>
+    <meta name="description" content="Researcher Reports">
     <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet">
   </head>
   <body>

--- a/researcher-reports/src/utils/translation/README.md
+++ b/researcher-reports/src/utils/translation/README.md
@@ -1,6 +1,6 @@
-# Results Loader Localization
+# Researcher Reports Localization
 
-The modules within `utils/translation` can be used to add text localization to results loader.
+The modules within `utils/translation` can be used to add text localization to Researcher Reports.
 
 ### How to use
 


### PR DESCRIPTION
This PR changes the name from "Results Loader" to "Researcher Reports" in a few more locations in the project and restores the QueryItem component that got lost in the last merge.
