### PR TITLE
Add support for iframe_interactive type in query

### DIFF
--- a/query-creator/create-query/steps/aws.js
+++ b/query-creator/create-query/steps/aws.js
@@ -177,11 +177,15 @@ exports.generateSQL = (queryId, resource, denormalizedResource) => {
           selectColumns.push(`submitted['${questionId}'] AS ${questionId}_submitted`);
         }
         break;
+      case "iframe_interactive":
+        selectColumnPrompts.push(`null AS ${questionId}_json`);
+        selectColumns.push(`kv1['${questionId}'] AS ${questionId}_json`);
+        break;
       case "managed_interactive":
       case "mw_interactive":
-        // TODO: add support for custom report fields
-        break;
       default:
+        selectColumnPrompts.push(`null AS ${questionId}_json`);
+        selectColumns.push(`kv1['${questionId}'] AS ${questionId}_json`);
         console.info(`Unknown question type: ${type}`);
         break;
     }

--- a/query-creator/create-query/tests/unit/test-handler.js
+++ b/query-creator/create-query/tests/unit/test-handler.js
@@ -54,7 +54,9 @@ describe('Query creation', function () {
                     { id: "managed_interactive_66666", type: "multiple_choice", prompt: "AP mc prompt", required: false,
                       choices: [{ content: "a", correct: true, id: 1 }, { content: "b", correct: false, id: 2 }, { content: "c", correct: false, id: 3 }]
                     },
-                    { id: "managed_interactive_77777", type: "image_question", prompt: "AP image prompt", required: false}
+                    { id: "managed_interactive_77777", type: "image_question", prompt: "AP image prompt", required: false},
+                    { id: "managed_interactive_88888", type: "iframe_interactive"},
+                    { id: "managed_interactive_99999", type: "unknown_type"}
                   ]
                 }
               ]
@@ -105,7 +107,9 @@ SELECT
   activities.questions['managed_interactive_66666'].prompt AS managed_interactive_66666_choice,
   activities.questions['managed_interactive_77777'].prompt AS managed_interactive_77777_image_url,
   null AS managed_interactive_77777_text,
-  null AS managed_interactive_77777_answer
+  null AS managed_interactive_77777_answer,
+  null AS managed_interactive_88888_json,
+  null AS managed_interactive_99999_json
 FROM activities
 
 UNION ALL
@@ -150,7 +154,9 @@ SELECT
   array_join(transform(CAST(json_extract(kv1['managed_interactive_66666'],'$.choice_ids') AS ARRAY(VARCHAR)), x -> CONCAT(activities.choices['managed_interactive_66666'][x].content, IF(activities.choices['managed_interactive_66666'][x].correct,' (correct)',' (wrong)'))),', ') AS managed_interactive_66666_choice,
   json_extract_scalar(kv1['managed_interactive_77777'], '$.image_url') AS managed_interactive_77777_image_url,
   json_extract_scalar(kv1['managed_interactive_77777'], '$.text') AS managed_interactive_77777_text,
-  kv1['managed_interactive_77777'] AS managed_interactive_77777_answer
+  kv1['managed_interactive_77777'] AS managed_interactive_77777_answer,
+  kv1['managed_interactive_88888'] AS managed_interactive_88888_json,
+  kv1['managed_interactive_99999'] AS managed_interactive_99999_json
 FROM activities,
   ( SELECT l.run_remote_endpoint remote_endpoint, arbitrary(l.runnable_url) runnable_url,arbitrary(l.learner_id) learner_id,arbitrary(l.student_id) student_id,arbitrary(l.user_id) user_id,arbitrary(l.student_name) student_name,arbitrary(l.username) username,arbitrary(l.school) school,arbitrary(l.class) class,arbitrary(l.class_id) class_id,arbitrary(l.permission_forms) permission_forms,arbitrary(l.last_run) last_run, arbitrary(l.teachers) teachers, map_agg(a.question_id, a.answer) kv1, map_agg(a.question_id, a.submitted) submitted
     FROM "report-service"."partitioned_answers" a


### PR DESCRIPTION
This PR adds support for questions of type `iframe_interactive` and unknown question types when generating the Athena query in the query creator lambda function.  When either are encountered, add a column that displays the full answer JSON.

Result query:
```
-- activity-activity_21051

WITH activities AS ( SELECT *, cardinality(questions) as num_questions FROM "report-service"."activity_structure" WHERE structure_id = 'd98e3905-814d-453c-8bc1-816af3b0e762' )

SELECT
  null as remote_endpoint,
  null as runnable_url,
  null as learner_id,
  null as student_id,
  null as user_id,
  null as student_name,
  null as username,
  null as school,
  null as class,
  null as class_id,
  null as permission_forms,
  null as last_run,
  null as teacher_user_ids,
  null as teacher_names,
  null as teacher_districts,
  null as teacher_states,
  null as teacher_emails,
  null as num_questions,
  null as num_answers,
  null as percent_complete,
  null AS managed_interactive_2679_json
FROM activities

UNION ALL

SELECT
  remote_endpoint,
  runnable_url,
  learner_id,
  student_id,
  user_id,
  student_name,
  username,
  school,
  class,
  class_id,
  permission_forms,
  last_run,
  array_join(transform(teachers, teacher -> teacher.user_id), ',') as teacher_user_ids,
  array_join(transform(teachers, teacher -> teacher.name), ',') as teacher_names,
  array_join(transform(teachers, teacher -> teacher.district), ',') as teacher_districts,
  array_join(transform(teachers, teacher -> teacher.state), ',') as teacher_states,
  array_join(transform(teachers, teacher -> teacher.email), ',') as teacher_emails,
  activities.num_questions,
  cardinality(array_intersect(map_keys(kv1),map_keys(activities.questions))) as num_answers,
  round(100.0 * cardinality(array_intersect(map_keys(kv1),map_keys(activities.questions))) / activities.num_questions, 1) as percent_complete,
  kv1['managed_interactive_2679'] AS managed_interactive_2679_json
FROM activities,
  ( SELECT l.run_remote_endpoint remote_endpoint, arbitrary(l.runnable_url) runnable_url,arbitrary(l.learner_id) learner_id,arbitrary(l.student_id) student_id,arbitrary(l.user_id) user_id,arbitrary(l.student_name) student_name,arbitrary(l.username) username,arbitrary(l.school) school,arbitrary(l.class) class,arbitrary(l.class_id) class_id,arbitrary(l.permission_forms) permission_forms,arbitrary(l.last_run) last_run, arbitrary(l.teachers) teachers, map_agg(a.question_id, a.answer) kv1, map_agg(a.question_id, a.submitted) submitted
    FROM "report-service"."partitioned_answers" a
    INNER JOIN "report-service"."learners" l
    ON (l.query_id = 'd98e3905-814d-453c-8bc1-816af3b0e762' AND l.run_remote_endpoint = a.remote_endpoint)
    WHERE a.escaped_url = 'https---authoring-staging-concord-org-activities-21051'
    GROUP BY l.run_remote_endpoint )

```

![image](https://user-images.githubusercontent.com/5126913/121736959-17a87100-caad-11eb-8fe9-7f21412f846a.png)
