### PR TITLE
Redirect to researcher reports

### DIFF
--- a/query-creator/create-query/app.js
+++ b/query-creator/create-query/app.js
@@ -63,12 +63,23 @@ exports.lambdaHandler = async (event, context) => {
       }
     }
 
-    const message = sqlOutput.length ? sqlOutput.join("\n\n------\n\n") : "Success"
+    let message = sqlOutput.length ? sqlOutput.join("\n\n------\n\n") : "Success"
 
-    // TODO: redirect the user to the result loader
-    return {
-      statusCode: 200,
-      body: message
+    if (debugSQL) {
+      return {
+        statusCode: 200,
+        body: message
+      }
+    } else {
+      message += "\n\nRedirecting to " + process.env.RESEARCHER_REPORTS_URL
+
+      return {
+        statusCode: 302,
+        headers: {
+          Location: process.env.RESEARCHER_REPORTS_URL,
+        },
+        body: message
+      }
     }
   } catch (err) {
     console.log(err);

--- a/query-creator/create-query/app.js
+++ b/query-creator/create-query/app.js
@@ -71,12 +71,14 @@ exports.lambdaHandler = async (event, context) => {
         body: message
       }
     } else {
-      message += "\n\nRedirecting to " + process.env.RESEARCHER_REPORTS_URL
+      const escapedPortalUrl = encodeURIComponent(portalUrl)
+      const reportsUrl =  `${process.env.RESEARCHER_REPORTS_URL}?portal=${escapedPortalUrl}`
+      message += "\n\nRedirecting to " + reportsUrl;
 
       return {
         statusCode: 302,
         headers: {
-          Location: process.env.RESEARCHER_REPORTS_URL,
+          Location: reportsUrl,
         },
         body: message
       }

--- a/query-creator/create-query/steps/env-vars.js
+++ b/query-creator/create-query/steps/env-vars.js
@@ -13,4 +13,7 @@ exports.validate = () => {
   if (!process.env.REPORT_SERVICE_URL) {
     missingVar("REPORT_SERVICE_URL");
   }
+  if (!process.env.RESEARCHER_REPORTS_URL) {
+    missingVar("RESEARCHER_REPORTS_URL");
+  }
 }

--- a/query-creator/samconfig.toml
+++ b/query-creator/samconfig.toml
@@ -9,7 +9,7 @@ s3_prefix = "report-service-query-creator"
 region = "us-east-1"
 confirm_changeset = true
 capabilities = "CAPABILITY_IAM"
-parameter_overrides = "OutputBucket=\"concordqa-report-data\" ReportServiceUrl=\"https://us-central1-report-service-dev.cloudfunctions.net/api\""
+parameter_overrides = "OutputBucket=\"concordqa-report-data\" ReportServiceUrl=\"https://us-central1-report-service-dev.cloudfunctions.net/api\" ResearcherReportsUrl=\"https://researcher-reports.concord.org/branch/master/\""
 
 [production]
 [production.deploy]
@@ -20,7 +20,7 @@ s3_prefix = "report-service-query-creator"
 region = "us-east-1"
 confirm_changeset = true
 capabilities = "CAPABILITY_IAM"
-parameter_overrides = "OutputBucket=\"concord-report-data\" ReportServiceUrl=\"https://us-central1-report-service-pro.cloudfunctions.net/api\""
+parameter_overrides = "OutputBucket=\"concord-report-data\" ReportServiceUrl=\"https://us-central1-report-service-pro.cloudfunctions.net/api\" ResearcherReportsUrl=\"https://researcher-reports.concord.org/\""
 
 [default.local_start_api.parameters]
 profile = "QueryCreatorLocalTestUser"

--- a/query-creator/template.yaml
+++ b/query-creator/template.yaml
@@ -13,6 +13,10 @@ Parameters:
   ReportServiceUrl:
     Type: String
     Description: URL for report service
+  ResearcherReportsUrl:
+    Type: String
+    Description: URL for researcher reports app
+    Default: https://localhost:8080
 
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
@@ -23,6 +27,7 @@ Globals:
         OUTPUT_BUCKET: !Ref OutputBucket
         REPORT_SERVICE_TOKEN: !Ref ReportServiceToken
         REPORT_SERVICE_URL: !Ref ReportServiceUrl
+        RESEARCHER_REPORTS_URL: !Ref ResearcherReportsUrl
 
 Resources:
   CreateQueryFunction:

--- a/researcher-reports/src/components/app.tsx
+++ b/researcher-reports/src/components/app.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { Resource, ResourceType, Credentials, AthenaResource } from "@concord-consortium/token-service";
+import { Resource, Credentials, AthenaResource } from "@concord-consortium/token-service";
 import * as AWS from "aws-sdk";
 import { Header } from "./header";
 import { QueryItem } from "./query-item";
@@ -35,14 +35,14 @@ export const App = () => {
     } else if (portalAccessTokenReturn.error) {
       setPortalAccessTokenStatus(portalAccessTokenReturn.error);
     }
-  }, []);
+  }, [portalUrl]);
 
   useEffect(() => {
     if (portalAccessToken) {
       setFirebaseJwtStatus("Getting Firebase JWT...");
       getFirebaseJwt(portalUrl, portalAccessToken, firebaseAppName).then(token => setFirebaseJwt(token));
     }
-  }, [portalAccessToken]);
+  }, [portalAccessToken, portalUrl]);
 
   useEffect(() => {
     const handleListMyResources = async () => {

--- a/researcher-reports/src/components/app.tsx
+++ b/researcher-reports/src/components/app.tsx
@@ -3,14 +3,14 @@ import { Resource, ResourceType, Credentials, AthenaResource } from "@concord-co
 import * as AWS from "aws-sdk";
 import { Header } from "./header";
 import { QueryItem } from "./query-item";
-import { readPortalAccessToken, getFirebaseJwt, listResources, getCredentials } from "../utils/results-utils";
+import { readPortalAccessToken, getFirebaseJwt, listResources, getCredentials, getURLParam } from "../utils/results-utils";
 
 import "./app.scss";
 
 type ResourceMap = {[key: string]: Resource};
 
 export const App = () => {
-  const portalUrl = "https://learn.staging.concord.org";
+  const portalUrl = getURLParam("portal") || "https://learn.concord.org";
   const oauthClientName = "athena-researcher-reports";
   const [portalAccessTokenStatus, setPortalAccessTokenStatus] = useState("");
   const [portalAccessToken, setPortalAccessToken] = useState("");

--- a/researcher-reports/src/components/app.tsx
+++ b/researcher-reports/src/components/app.tsx
@@ -10,9 +10,6 @@ import "./app.scss";
 type ResourceMap = {[key: string]: Resource};
 
 export const App = () => {
-  // const tokenServiceEnv = "staging";
-  // const resourceType = "s3Folder";
-
   const portalUrl = "https://learn.staging.concord.org";
   const oauthClientName = "athena-researcher-reports";
   const [portalAccessTokenStatus, setPortalAccessTokenStatus] = useState("");
@@ -26,7 +23,6 @@ export const App = () => {
   const [resourcesStatus, setResourcesStatus] = useState("");
   const [resources, setResources] = useState({} as ResourceMap);
   const [currentResource, setCurrentResource] = useState<Resource | undefined>();
-  const resourceType = "athenaWorkgroup";
 
   const [credentialsStatus, setCredentialsStatus] = useState("");
   const [credentials, setCredentials] = useState<Credentials | undefined>();
@@ -51,7 +47,7 @@ export const App = () => {
   useEffect(() => {
     const handleListMyResources = async () => {
       setResourcesStatus("Loading resources...");
-      const resourceList = await listResources(firebaseJwt, true, tokenServiceEnv, resourceType as ResourceType);
+      const resourceList = await listResources(firebaseJwt, tokenServiceEnv);
       if(resourceList.length === 0) {
         setResourcesStatus("No resources found");
       } else {

--- a/researcher-reports/src/utils/results-utils.ts
+++ b/researcher-reports/src/utils/results-utils.ts
@@ -57,12 +57,11 @@ export const getCredentials = async ({resource, firebaseJwt,
   return client.getCredentials(resource.id);
 };
 
-export const listResources = async (firebaseJwt: string, amOwner: boolean,
-  tokenServiceEnv: EnvironmentName, resourceType: ResourceType) => {
+export const listResources = async (firebaseJwt: string, tokenServiceEnv: EnvironmentName) => {
   const client = new TokenServiceClient({ jwt: firebaseJwt, env: tokenServiceEnv });
   return client.listResources({
-    type: resourceType,
+    type: "athenaWorkgroup",
     tool: "researcher-report",
-    amOwner: amOwner ? "true" : "false"
+    amOwner: "true"
   });
 };

--- a/researcher-reports/src/utils/results-utils.ts
+++ b/researcher-reports/src/utils/results-utils.ts
@@ -1,5 +1,5 @@
 import ClientOAuth2 from "client-oauth2";
-import { TokenServiceClient, EnvironmentName, ResourceType, Resource, Credentials } from "@concord-consortium/token-service";
+import { TokenServiceClient, EnvironmentName, Resource, Credentials } from "@concord-consortium/token-service";
 
 const PORTAL_AUTH_PATH = "/auth/oauth_authorize";
 

--- a/researcher-reports/src/utils/results-utils.ts
+++ b/researcher-reports/src/utils/results-utils.ts
@@ -3,7 +3,7 @@ import { TokenServiceClient, EnvironmentName, ResourceType, Resource, Credential
 
 const PORTAL_AUTH_PATH = "/auth/oauth_authorize";
 
-const getURLParam = (name: string) => {
+export const getURLParam = (name: string) => {
   const url = (self || window).location.href;
   name = name.replace(/[[]]/g, "\\$&");
   const regex = new RegExp(`[#?&]${name}(=([^&#]*)|&|#|$)`);
@@ -31,7 +31,9 @@ export const readPortalAccessToken = (portalUrl: string, oauthClientName: string
     // c.f. https://stackoverflow.com/questions/22753052/remove-url-parameters-without-refreshing-page
     if (window.history?.pushState !== undefined) {
       // if pushstate exists, add a new state to the history, this changes the url without reloading the page
-      window.history.pushState({}, document.title, window.location.pathname);
+      // preserve the portal url parameter
+      const appUrl = window.location.pathname + "?portal=" + getURLParam("portal");
+      window.history.pushState({}, document.title, appUrl);
     }
   }
   return {accessToken: accessToken || "", error};


### PR DESCRIPTION
This adds the redirect to the researcher-reports app after the queries have been kicked off in Athena (unless `debugSQL=true` is in the query params).

The researcher-reports url is defined in an env variable set on deploy. This will not usually need to change for different portals, but it seemed helpful to have staging point to the master branch of the reports app.

When the query-creator loads, it extracts the portal url from the learner-api url that is passed in by the JWT. It then opens the researcher-reports with `?portal=purtalUrl`. The researcher reports app is updated to find this query param and use it for authentication with the portal. When the app later strips out the token, we preserve this param because we later need to make a request to the same portal for the JWT.

If the researcher-report is launched with no query param, it defaults to learn.portal.