### PR TITLE
Researcher Report: Improve layout and text in report and status/debug sections

### DIFF
--- a/researcher-reports/src/components/app.scss
+++ b/researcher-reports/src/components/app.scss
@@ -30,6 +30,23 @@
     box-sizing: border-box;
     width: calc(100% - 80px);
 
+    .container {
+      border: solid 1px $cc-charcoal;;
+      border-radius: 5px;
+      padding: 20px 15px 10px 15px;
+      margin: 0 0 20px 0;
+      position: relative;
+
+      .container-title {
+        position: absolute;
+        top: -10px;
+        left: 20px;
+        background-color: white;
+        width: fit-content;
+        padding: 0 5px;
+      }
+    }
+
     .info {
       margin: 10px 0;
       white-space: nowrap;

--- a/researcher-reports/src/components/app.tsx
+++ b/researcher-reports/src/components/app.tsx
@@ -87,7 +87,7 @@ export const App = () => {
   useEffect(() => {
     const handleListQueryExecutions = async () => {
       if (!credentials || !currentResource) return;
-      setQueriesStatus("Loading queries...");
+      setQueriesStatus("Loading reports...");
       const { region } = currentResource as AthenaResource;
       const { accessKeyId, secretAccessKey, sessionToken } = credentials;
       const athena = new AWS.Athena({ region, accessKeyId, secretAccessKey, sessionToken });
@@ -106,46 +106,51 @@ export const App = () => {
     <div className="app">
       <Header />
       <div className="content">
-        { portalAccessToken
-          ? <div className="info">{`Portal Access Token: ${portalAccessToken}`}</div>
-          : <div>{portalAccessTokenStatus}</div>
-        }
-        { firebaseJwt
-          ? <div className="info">{`Firebase JWT: ${firebaseJwt.slice(0, 40)}...`}</div>
-          : <div>{firebaseJwtStatus}</div>
-        }
-        { Object.keys(resources).length > 0 &&
-          <div className="info">
-            {Object.keys(resources).length} Athena workgroup resource{Object.keys(resources).length > 1 ? "s" : ""} found
-          </div>
-        }
-        { currentResource
-          ? <div className="info">Athena workgroup current resource:
-              <div className="sub-info">id: {currentResource.id}</div>
-              <div className="sub-info">name: {currentResource.name}</div>
-              <div className="sub-info">description: {currentResource.description}</div>
+        <div className="container">
+          <div className="container-title">Reports</div>
+          { queries
+            ? credentials && currentResource && queries?.map((query, i) =>
+              <QueryItem
+                key={`query-${i}`}
+                queryExecutionId={query}
+                credentials={credentials}
+                currentResource={currentResource}
+              /> )
+            : <div>{queriesStatus}</div>
+          }
+        </div>
+        <div className="container">
+          <div className="container-title">Report Access Status</div>
+          { portalAccessToken
+            ? <div className="info">{`Portal Access Token: ${portalAccessToken}`}</div>
+            : <div>{portalAccessTokenStatus}</div>
+          }
+          { firebaseJwt
+            ? <div className="info">{`Firebase JWT: ${firebaseJwt.slice(0, 40)}...`}</div>
+            : <div>{firebaseJwtStatus}</div>
+          }
+          { Object.keys(resources).length > 0 &&
+            <div className="info">
+              {Object.keys(resources).length} Athena workgroup resource{Object.keys(resources).length > 1 ? "s" : ""} found
             </div>
-          : <div>{resourcesStatus}</div>
-        }
-        { credentials
-          ? <div className="info">Athena workgroup current resource credentials:
-              <div className="sub-info">access key id: {credentials.accessKeyId}</div>
-              <div className="sub-info">secret access key: {credentials.secretAccessKey}</div>
-              <div className="sub-info">session token: ${credentials.sessionToken.slice(0, 40)}...</div>
-            </div>
-          : <div>{credentialsStatus}</div>
-        }
-        { queries && <div className="info">Queries: </div>}
-        { queries
-          ? credentials && currentResource && queries?.map((query, i) =>
-            <QueryItem
-              key={`query-${i}`}
-              queryExecutionId={query}
-              credentials={credentials}
-              currentResource={currentResource}
-            /> )
-          : <div>{queriesStatus}</div>
-        }
+          }
+          { currentResource
+            ? <div className="info">Athena workgroup current resource:
+                <div className="sub-info">id: {currentResource.id}</div>
+                <div className="sub-info">name: {currentResource.name}</div>
+                <div className="sub-info">description: {currentResource.description}</div>
+              </div>
+            : <div>{resourcesStatus}</div>
+          }
+          { credentials
+            ? <div className="info">Athena workgroup current resource credentials:
+                <div className="sub-info">access key id: {credentials.accessKeyId}</div>
+                <div className="sub-info">secret access key: {credentials.secretAccessKey}</div>
+                <div className="sub-info">session token: ${credentials.sessionToken.slice(0, 40)}...</div>
+              </div>
+            : <div>{credentialsStatus}</div>
+          }
+        </div>
       </div>
     </div>
   );

--- a/researcher-reports/src/components/query-item.scss
+++ b/researcher-reports/src/components/query-item.scss
@@ -8,9 +8,9 @@
   background-color: #efefef;
   border: solid 1px darkgray;
   border-radius: 2px;
-  padding: 3px 10px;
+  padding: 3px 6px;
 
-  &:nth-child(even) {
+  &:nth-child(odd) {
     background-color: white;
     border-top: none;
   }


### PR DESCRIPTION
This PR improves the layout and text in the researcher report so it is more clear where the reports are and what the status/debugging information is for.  Changes include:
- move reports above debug/status info
- use "report" instead of "query" in user-facing text
- add border and title around report and debug/status sections to make them more clear

![image](https://user-images.githubusercontent.com/5126913/122282561-646ebc00-cea0-11eb-87b5-88ccbe54ed1d.png)
