### PR TITLE
178546257 resource name

### DIFF
--- a/query-creator/create-query/app.js
+++ b/query-creator/create-query/app.js
@@ -56,7 +56,7 @@ exports.lambdaHandler = async (event, context) => {
       const sql = aws.generateSQL(queryId, resource, denormalizedResource)
 
       if (debugSQL) {
-        sqlOutput.push(`-- ${resource.id}\n\n${sql}`);
+        sqlOutput.push(`-- id ${resource.id}\n${sql}`);
       } else {
         // create the athena query in the workgroup
         await aws.startQueryExecution(sql, workgroupName)

--- a/query-creator/create-query/steps/aws.js
+++ b/query-creator/create-query/steps/aws.js
@@ -211,7 +211,10 @@ exports.generateSQL = (queryId, resource, denormalizedResource) => {
   const assignTeacherMetaData = teacherMetadataColumns.map(tmd => `array_join(transform(teachers, teacher -> teacher.${tmd[1]}), ',') as ${tmd[0]}`)
   const assignTeacherVar = "arbitrary(l.teachers) teachers"
 
-  return `WITH activities AS ( SELECT *, cardinality(questions) as num_questions FROM "report-service"."activity_structure" WHERE structure_id = '${queryId}' )
+  return `-- name ${resource.name}
+-- type ${resource.type}
+
+WITH activities AS ( SELECT *, cardinality(questions) as num_questions FROM "report-service"."activity_structure" WHERE structure_id = '${queryId}' )
 
 SELECT
   ${[`null as remote_endpoint,\n${nullAsMetadata}${nullAsTeacherMetadata}  null as num_questions,\n  null as num_answers,\n  null as percent_complete`].concat(selectColumnPrompts).join(",\n  ")}

--- a/query-creator/create-query/tests/unit/test-handler.js
+++ b/query-creator/create-query/tests/unit/test-handler.js
@@ -28,6 +28,7 @@ describe('Query creation', function () {
         const testQueryId = "123456789";
         const testResource = {
           url: "https://authoring.staging.concord.org/activities/000000",
+          name: "test activity",
           type: "activity",
           children: [
             { type: "section",
@@ -65,7 +66,10 @@ describe('Query creation', function () {
         };
         const testDenormalizedResource = firebase.denormalizeResource(testResource);
         const generatedSQLresult = await aws.generateSQL(testQueryId, testResource, testDenormalizedResource);
-        const expectedSQLresult = `WITH activities AS ( SELECT *, cardinality(questions) as num_questions FROM "report-service"."activity_structure" WHERE structure_id = '123456789' )
+        const expectedSQLresult = `-- name test activity
+-- type activity
+
+WITH activities AS ( SELECT *, cardinality(questions) as num_questions FROM "report-service"."activity_structure" WHERE structure_id = '123456789' )
 
 SELECT
   null as remote_endpoint,

--- a/researcher-reports/src/components/query-item.tsx
+++ b/researcher-reports/src/components/query-item.tsx
@@ -14,6 +14,8 @@ interface IProps {
 export const QueryItem: React.FC<IProps> = (props) => {
   const { queryExecutionId, credentials, currentResource } = props;
   const [queryExecutionStatus, setQueryExecutionStatus] = useState("Loading query information...");
+  const [resourceName, setResourceName] = useState("");
+  const [resourceType, setResourceType] = useState("");
   const [submissionDateTime, setSubmissionDateTime] = useState("");
   const [queryCompletionStatus, setQueryCompletionStatus] = useState("");
   const [outputLocationBucket, setOutputLocationBucket] = useState("");
@@ -31,6 +33,20 @@ export const QueryItem: React.FC<IProps> = (props) => {
       const results = await athena.getQueryExecution({
         QueryExecutionId: queryExecutionId
       }).promise();
+
+      const query = results.QueryExecution?.Query;
+      const nameLoc = query?.search("-- name");
+      const typeLoc = query?.search("-- type");
+      if (nameLoc !== undefined && nameLoc >= 0) {
+        const nameStartStr = query?.substring(nameLoc + 8);
+        const _resourceName = nameStartStr?.substring(0, nameStartStr.search(/\n/));
+        _resourceName && setResourceName(_resourceName);
+      }
+      if (typeLoc !== undefined && typeLoc >= 0) {
+        const typeStartStr = query?.substring(typeLoc + 8);
+        const _resourceType = typeStartStr?.substring(0, typeStartStr.search(/\n/));
+        _resourceType && setResourceType(_resourceType);
+      }
 
       setSubmissionDateTime(results.QueryExecution?.Status?.SubmissionDateTime?.toUTCString()
        || "Error getting query submission date and time");
@@ -82,6 +98,8 @@ export const QueryItem: React.FC<IProps> = (props) => {
       { queryExecutionStatus
         ? queryExecutionStatus
         : <div className="info-container">
+            {resourceName && <div className="item-info">{`Name: ${resourceName}`}</div>}
+            {resourceType && <div className="item-info">{`Type: ${resourceType}`}</div>}
             <div className="item-info">{`Creation date: ${submissionDateTime}`}</div>
             <div className="item-info">{`Completion status: ${queryCompletionStatus.toLowerCase()}`}</div>
             { !downloadURL


### PR DESCRIPTION
This PR adds the resource name and resource type to the top of the Athena query as a comment.  This can then be used in the Researcher Report to display the name and type to the user.  The full query contents are pulled from the execution info and we then parse out the name and type.  If we find them, we show them to the user.  The resource id is still added as a comment if we are in debug mode.

![image](https://user-images.githubusercontent.com/5126913/122465566-1b386e00-cf6d-11eb-8c3a-b4de97f26a43.png)

Example query:
```
-- name Example OR, MC, and IQ managed interactive questions 
-- type activity

WITH activities AS ( SELECT *, cardinality(questions) as num_questions FROM "report-service"."activity_structure" WHERE structure_id = '1029f7ea-4af7-4c6c-83a8-0abe45487d4f' )

SELECT
  null as remote_endpoint,
  null as runnable_url,
  null as learner_id,
  null as student_id,
  null as user_id,
  null as student_name,
  null as username,
  null as school,
  null as class,
  null as class_id,
  null as permission_forms,
  null as last_run,
  null as teacher_user_ids,
  null as teacher_names,
  null as teacher_districts,
  null as teacher_states,
  null as teacher_emails,
  null as num_questions,
  null as num_answers,
  null as percent_complete,
  activities.questions['managed_interactive_2475'].prompt AS managed_interactive_2475_text,
  activities.questions['managed_interactive_2476'].prompt AS managed_interactive_2476_choice,
  activities.questions['managed_interactive_2478'].prompt AS managed_interactive_2478_image_url,
  null AS managed_interactive_2478_text,
  null AS managed_interactive_2478_answer,
  activities.questions['managed_interactive_2482'].prompt AS managed_interactive_2482_image_url,
  null AS managed_interactive_2482_text,
  null AS managed_interactive_2482_answer,
  null AS managed_interactive_2479_json
FROM activities

UNION ALL

SELECT
  remote_endpoint,
  runnable_url,
  learner_id,
  student_id,
  user_id,
  student_name,
  username,
  school,
  class,
  class_id,
  permission_forms,
  last_run,
  array_join(transform(teachers, teacher -> teacher.user_id), ',') as teacher_user_ids,
  array_join(transform(teachers, teacher -> teacher.name), ',') as teacher_names,
  array_join(transform(teachers, teacher -> teacher.district), ',') as teacher_districts,
  array_join(transform(teachers, teacher -> teacher.state), ',') as teacher_states,
  array_join(transform(teachers, teacher -> teacher.email), ',') as teacher_emails,
  activities.num_questions,
  cardinality(array_intersect(map_keys(kv1),map_keys(activities.questions))) as num_answers,
  round(100.0 * cardinality(array_intersect(map_keys(kv1),map_keys(activities.questions))) / activities.num_questions, 1) as percent_complete,
  kv1['managed_interactive_2475'] AS managed_interactive_2475_text,
  array_join(transform(CAST(json_extract(kv1['managed_interactive_2476'],'$.choice_ids') AS ARRAY(VARCHAR)), x -> CONCAT(activities.choices['managed_interactive_2476'][x].content, '')),', ') AS managed_interactive_2476_choice,
  json_extract_scalar(kv1['managed_interactive_2478'], '$.image_url') AS managed_interactive_2478_image_url,
  json_extract_scalar(kv1['managed_interactive_2478'], '$.text') AS managed_interactive_2478_text,
  kv1['managed_interactive_2478'] AS managed_interactive_2478_answer,
  json_extract_scalar(kv1['managed_interactive_2482'], '$.image_url') AS managed_interactive_2482_image_url,
  json_extract_scalar(kv1['managed_interactive_2482'], '$.text') AS managed_interactive_2482_text,
  kv1['managed_interactive_2482'] AS managed_interactive_2482_answer,
  kv1['managed_interactive_2479'] AS managed_interactive_2479_json
FROM activities,
  ( SELECT l.run_remote_endpoint remote_endpoint, arbitrary(l.runnable_url) runnable_url,arbitrary(l.learner_id) learner_id,arbitrary(l.student_id) student_id,arbitrary(l.user_id) user_id,arbitrary(l.student_name) student_name,arbitrary(l.username) username,arbitrary(l.school) school,arbitrary(l.class) class,arbitrary(l.class_id) class_id,arbitrary(l.permission_forms) permission_forms,arbitrary(l.last_run) last_run, arbitrary(l.teachers) teachers, map_agg(a.question_id, a.answer) kv1, map_agg(a.question_id, a.submitted) submitted
    FROM "report-service"."partitioned_answers" a
    INNER JOIN "report-service"."learners" l
    ON (l.query_id = '1029f7ea-4af7-4c6c-83a8-0abe45487d4f' AND l.run_remote_endpoint = a.remote_endpoint)
    WHERE a.escaped_url = 'https---authoring-staging-concord-org-activities-21026'
    GROUP BY l.run_remote_endpoint )
```