### PR TITLE
Query Creator: Add usageReport URL param to create report with no answers

### DIFF
--- a/query-creator/create-query/app.js
+++ b/query-creator/create-query/app.js
@@ -13,6 +13,7 @@ exports.lambdaHandler = async (event, context) => {
     const reportServiceSource = params.reportServiceSource;
     const debugSQL = params.debugSQL || false;
     const tokenServiceEnv = params.tokenServiceEnv;
+    const usageReport = params.usageReport || false;
 
     if (!reportServiceSource) {
       throw new Error("Missing reportServiceSource in the report url");
@@ -53,7 +54,7 @@ exports.lambdaHandler = async (event, context) => {
       await aws.uploadDenormalizedResource(queryId, denormalizedResource);
 
       // generate the sql for the query
-      const sql = aws.generateSQL(queryId, resource, denormalizedResource)
+      const sql = aws.generateSQL(queryId, resource, denormalizedResource, usageReport);
 
       if (debugSQL) {
         sqlOutput.push(`-- id ${resource.id}\n${sql}`);


### PR DESCRIPTION
This PR adds a `usageReport` URL parameter to Query Creator.  When set to true, the `generateSQL` function will create a smaller query that does not include the answer data.  

To test, pull this branch, run a local version of the query creator (`sam build`, `sam local start-api`) and then login to the learner report:
https://learn-report.staging.concord.org/report/learner
Enter filter values and then press the "SAM Query Creator Local (debugSQL usageReport)" button.  This will generate the SQL to make a usage report.

![image](https://user-images.githubusercontent.com/5126913/122598407-a3784b00-d021-11eb-807e-37fd551cc1c8.png)

We will also need to add a final button to the learner report page that launches the actual lambda, but that can wait until after this PR is merged.  

Example usageReport query:
```
-- id activity-activity_21026
-- name Example OR, MC, and IQ managed interactive questions 
-- type activity

WITH activities AS ( SELECT *, cardinality(questions) as num_questions FROM "report-service"."activity_structure" WHERE structure_id = '525a070a-9510-480a-b124-829f771fd95e' )

SELECT
  remote_endpoint,
  runnable_url,
  learner_id,
  student_id,
  user_id,
  student_name,
  username,
  school,
  class,
  class_id,
  permission_forms,
  last_run,
  array_join(transform(teachers, teacher -> teacher.user_id), ',') as teacher_user_ids,
  array_join(transform(teachers, teacher -> teacher.name), ',') as teacher_names,
  array_join(transform(teachers, teacher -> teacher.district), ',') as teacher_districts,
  array_join(transform(teachers, teacher -> teacher.state), ',') as teacher_states,
  array_join(transform(teachers, teacher -> teacher.email), ',') as teacher_emails,
  activities.num_questions,
  cardinality(array_intersect(map_keys(kv1),map_keys(activities.questions))) as num_answers,
  round(100.0 * cardinality(array_intersect(map_keys(kv1),map_keys(activities.questions))) / activities.num_questions, 1) as percent_complete
FROM activities,
  ( SELECT l.run_remote_endpoint remote_endpoint, arbitrary(l.runnable_url) runnable_url,arbitrary(l.learner_id) learner_id,arbitrary(l.student_id) student_id,arbitrary(l.user_id) user_id,arbitrary(l.student_name) student_name,arbitrary(l.username) username,arbitrary(l.school) school,arbitrary(l.class) class,arbitrary(l.class_id) class_id,arbitrary(l.permission_forms) permission_forms,arbitrary(l.last_run) last_run, arbitrary(l.teachers) teachers, map_agg(a.question_id, a.answer) kv1, map_agg(a.question_id, a.submitted) submitted
    FROM "report-service"."partitioned_answers" a
    INNER JOIN "report-service"."learners" l
    ON (l.query_id = '525a070a-9510-480a-b124-829f771fd95e' AND l.run_remote_endpoint = a.remote_endpoint)
    WHERE a.escaped_url = 'https---authoring-staging-concord-org-activities-21026'
    GROUP BY l.run_remote_endpoint )
```

Query Results:
![image](https://user-images.githubusercontent.com/5126913/122597916-eede2980-d020-11eb-90a8-7438d80f9e2a.png)

