### PR TITLE
Use production token service on production

### DIFF
--- a/researcher-reports/src/components/app.tsx
+++ b/researcher-reports/src/components/app.tsx
@@ -64,7 +64,7 @@ export const App = () => {
     if (portalAccessToken && firebaseJwt) {
       handleListMyResources();
     }
-  }, [portalAccessToken, firebaseJwt]);
+  }, [portalAccessToken, firebaseJwt, tokenServiceEnv]);
 
   useEffect(() => {
     const handleGetCredentials = async () => {
@@ -81,7 +81,7 @@ export const App = () => {
     if (portalAccessToken && firebaseJwt && currentResource) {
       handleGetCredentials();
     }
-  }, [portalAccessToken, firebaseJwt, currentResource]);
+  }, [portalAccessToken, firebaseJwt, currentResource, tokenServiceEnv]);
 
   const [queriesStatus, setQueriesStatus] = useState("");
   const [queries, setQueries] = useState<string[] | undefined>();

--- a/researcher-reports/src/components/app.tsx
+++ b/researcher-reports/src/components/app.tsx
@@ -19,7 +19,9 @@ export const App = () => {
   const [firebaseJwtStatus, setFirebaseJwtStatus] = useState("");
   const [firebaseJwt, setFirebaseJwt] = useState("");
 
-  const tokenServiceEnv = "staging";
+  // use "production" token service env only if we're on the production url
+  const isProduction = window.location.host === "researcher-reports.concord.org" && window.location.pathname.indexOf("branch") < 0;
+  const tokenServiceEnv = isProduction ?"production" : "staging";
   const [resourcesStatus, setResourcesStatus] = useState("");
   const [resources, setResources] = useState({} as ResourceMap);
   const [currentResource, setCurrentResource] = useState<Resource | undefined>();

--- a/researcher-reports/src/utils/results-utils.ts
+++ b/researcher-reports/src/utils/results-utils.ts
@@ -31,8 +31,14 @@ export const readPortalAccessToken = (portalUrl: string, oauthClientName: string
     // c.f. https://stackoverflow.com/questions/22753052/remove-url-parameters-without-refreshing-page
     if (window.history?.pushState !== undefined) {
       // if pushstate exists, add a new state to the history, this changes the url without reloading the page
-      // preserve the portal url parameter
-      const appUrl = window.location.pathname + "?portal=" + getURLParam("portal");
+      // preserve the portal url.
+      // We only preserve url param if it was passed in, so we don't change the url unnecessarily
+      const escapedPortalUrl = getURLParam("portal");
+      const query = new URLSearchParams();
+      if (escapedPortalUrl) {
+        query.set("portal", escapedPortalUrl);
+      }
+      const appUrl = `${window.location.pathname}?${query.toString()}`;
       window.history.pushState({}, document.title, appUrl);
     }
   }


### PR DESCRIPTION
This tests to see if we're running on the production url, and, if so, use "production" tokenServiceEnv. Otherwise default to "staging".