### PR TITLE
Query Creator: Handle unreportable runnables in query creation

### DIFF
--- a/query-creator/create-query/app.js
+++ b/query-creator/create-query/app.js
@@ -47,17 +47,24 @@ exports.lambdaHandler = async (event, context) => {
       const queryId = queryIdsPerRunnable[runnableUrl];
 
       // get and denormalize the resource (activity or sequence) from Firebase
-      const resource = await firebase.getResource(runnableUrl, reportServiceSource);
-      const denormalizedResource = firebase.denormalizeResource(resource);
+      let resource;
+      let denormalizedResource;
+      try {
+        resource = await firebase.getResource(runnableUrl, reportServiceSource);
+        denormalizedResource = firebase.denormalizeResource(resource);
 
-      // upload the denormalized resource to s3 and tie it to the workgroup
-      await aws.uploadDenormalizedResource(queryId, denormalizedResource);
+        // upload the denormalized resource to s3 and tie it to the workgroup
+        await aws.uploadDenormalizedResource(queryId, denormalizedResource);
+      } catch (err) {
+        // no valid resource, we will attempt to create a usage report with just the learner data
+        console.log(err);
+      }
 
       // generate the sql for the query
-      const sql = aws.generateSQL(queryId, resource, denormalizedResource, usageReport);
+      const sql = aws.generateSQL(queryId, resource, denormalizedResource, usageReport, runnableUrl);
 
       if (debugSQL) {
-        sqlOutput.push(`-- id ${resource.id}\n${sql}`);
+        sqlOutput.push(`${resource ? `-- id ${resource.id}` : `-- url ${runnableUrl}`}\n${sql}`);
       } else {
         // create the athena query in the workgroup
         await aws.startQueryExecution(sql, workgroupName)

--- a/query-creator/create-query/tests/unit/test-handler.js
+++ b/query-creator/create-query/tests/unit/test-handler.js
@@ -219,3 +219,43 @@ FROM activities,
       expect(untabbedGeneratedSQLresult).to.be.equal(untabbedExpectedSQLresult);
   });
 });
+
+
+
+describe('Query creation unreportable runnable', function () {
+  it('verifies successful query creation of unreportable runnable', async () => {
+      const generatedSQLresult = await aws.generateSQL(testQueryId, undefined, undefined, false, "www.test.url");
+      const expectedSQLresult = `-- name www.test.url
+-- type assignment
+
+
+
+SELECT
+  remote_endpoint,
+  runnable_url,
+  learner_id,
+  student_id,
+  user_id,
+  student_name,
+  username,
+  school,
+  class,
+  class_id,
+  permission_forms,
+  last_run,
+  array_join(transform(teachers, teacher -> teacher.user_id), ',') as teacher_user_ids,
+  array_join(transform(teachers, teacher -> teacher.name), ',') as teacher_names,
+  array_join(transform(teachers, teacher -> teacher.district), ',') as teacher_districts,
+  array_join(transform(teachers, teacher -> teacher.state), ',') as teacher_states,
+  array_join(transform(teachers, teacher -> teacher.email), ',') as teacher_emails
+FROM
+  ( SELECT l.run_remote_endpoint remote_endpoint, arbitrary(l.runnable_url) runnable_url,arbitrary(l.learner_id) learner_id,arbitrary(l.student_id) student_id,arbitrary(l.user_id) user_id,arbitrary(l.student_name) student_name,arbitrary(l.username) username,arbitrary(l.school) school,arbitrary(l.class) class,arbitrary(l.class_id) class_id,arbitrary(l.permission_forms) permission_forms,arbitrary(l.last_run) last_run, arbitrary(l.teachers) teachers
+    FROM "report-service"."learners" l
+    WHERE l.query_id = '123456789'
+    GROUP BY l.run_remote_endpoint )`;
+
+      const untabbedGeneratedSQLresult = generatedSQLresult.replace("\t", "");
+      const untabbedExpectedSQLresult = expectedSQLresult.replace("\t", "");
+      expect(untabbedGeneratedSQLresult).to.be.equal(untabbedExpectedSQLresult);
+  });
+});


### PR DESCRIPTION
This PR handles unreportable runnables (runnables where we cannot access a resource from Firebase).  In this case, we strip out all answer and completion information from the SQL query and generate a report that contains only learner data (including the last run info).  This report is essentially the usage report without the completion information.  Changes include:
- when we cannot access a valid resource, we still call `generateSQL`, but attempt to create a simplified report with only learner data.
- add unit tests

Some notes:
- the same report is generated for both the details and the usage report.  I originally implemented skipping unreportable runnables when the user requested a details report, but in practice this felt confusing and is likely to leave a user thinking that the report is *somewhere* in the list in the researcher reports page.  I think the better solution is to generate *something* for the user in both cases.
- I'm not crazy about some of the conditionals in `generateSQL`.  If this function has to grow much more in the near future, we might consider refactoring it into multiple functions.
- it's worth looking at my query and seeing if it looks ok.  I developed and tested with a CLUE assignment.

Sample query:
```
SELECT
  remote_endpoint,
  runnable_url,
  learner_id,
  student_id,
  user_id,
  student_name,
  username,
  school,
  class,
  class_id,
  permission_forms,
  last_run,
  array_join(transform(teachers, teacher -> teacher.user_id), ',') as teacher_user_ids,
  array_join(transform(teachers, teacher -> teacher.name), ',') as teacher_names,
  array_join(transform(teachers, teacher -> teacher.district), ',') as teacher_districts,
  array_join(transform(teachers, teacher -> teacher.state), ',') as teacher_states,
  array_join(transform(teachers, teacher -> teacher.email), ',') as teacher_emails
FROM
(SELECT l.run_remote_endpoint remote_endpoint, arbitrary(l.runnable_url) runnable_url,arbitrary(l.learner_id) learner_id,arbitrary(l.student_id) student_id,arbitrary(l.user_id) user_id,arbitrary(l.student_name) student_name,arbitrary(l.username) username,arbitrary(l.school) school,arbitrary(l.class) class,arbitrary(l.class_id) class_id,arbitrary(l.permission_forms) permission_forms,arbitrary(l.last_run) last_run, arbitrary(l.teachers) teachers
    FROM "report-service"."learners" l
    WHERE l.query_id = 'eb7782ed-cb11-4a18-8d72-28bcc648ed1f' 
    GROUP BY l.run_remote_endpoint)
```

Sample results:
![image](https://user-images.githubusercontent.com/5126913/123035956-1cb8ca80-d3a1-11eb-918b-b97df7eb0a1f.png)
