### PR TITLE
Add query support for learners with no answers

### DIFF
--- a/query-creator/create-query/steps/aws.js
+++ b/query-creator/create-query/steps/aws.js
@@ -282,14 +282,6 @@ UNION ALL
 `;
     }
 
-    // const answerMaps = `map_agg(a.question_id, a.answer) kv1, map_agg(a.question_id, a.submitted) submitted`;
-
-    // groupedSubSelect = `SELECT ${groupingSelect}, ${answerMaps}
-    // FROM "report-service"."partitioned_answers" a
-    // INNER JOIN "report-service"."learners" l
-    // ON (l.query_id = '${queryId}' AND l.run_remote_endpoint = a.remote_endpoint)
-    // WHERE a.escaped_url = '${escapedUrl}'
-    // GROUP BY l.run_remote_endpoint`;
   } else {
     groupedSubSelect = `
   ( SELECT ${groupingSelect}

--- a/query-creator/create-query/steps/aws.js
+++ b/query-creator/create-query/steps/aws.js
@@ -173,7 +173,9 @@ const getColumnsForQuestion = (questionId, question, denormalizedResource) => {
 
 exports.generateSQL = (queryId, resource, denormalizedResource, usageReport, runnableUrl) => {
   const hasResource = !!resource;
-  let escapedUrl;
+  const escapedUrl = hasResource
+    ? resource.url.replace(/[^a-z0-9]/g, "-")
+    : runnableUrl.replace(/[^a-z0-9]/g, "-");
 
   const metadataColumnNames = [
     "runnable_url",
@@ -226,6 +228,23 @@ exports.generateSQL = (queryId, resource, denormalizedResource, usageReport, run
   const groupingSelectMetadataColumns = metadataColumnsForGrouping.map(selectFromColumn).join(", ");
 
   const groupingSelect = `l.run_remote_endpoint remote_endpoint, ${groupingSelectMetadataColumns}, ${assignTeacherVar}`
+  const answerMaps = `map_agg(a.question_id, a.answer) kv1, map_agg(a.question_id, a.submitted) submitted`;
+
+  const groupedAnswers = hasResource ? `grouped_answers AS ( SELECT l.run_remote_endpoint remote_endpoint, ${answerMaps}
+  FROM "report-service"."partitioned_answers" a
+  INNER JOIN "report-service"."learners" l
+  ON (l.query_id = '${queryId}' AND l.run_remote_endpoint = a.remote_endpoint)
+  WHERE a.escaped_url = '${escapedUrl}'
+  GROUP BY l.run_remote_endpoint ),`
+  : "";
+
+  const learnersAndAnswers = hasResource ? `learners_and_answers AS ( SELECT run_remote_endpoint remote_endpoint, runnable_url, learner_id, student_id, user_id, student_name, username, school, class, class_id, permission_forms, last_run, teachers, grouped_answers.kv1 kv1, grouped_answers.submitted submitted,
+  IF (kv1 is null, 0, cardinality(array_intersect(map_keys(kv1),map_keys(activities.questions)))) num_answers
+  FROM activities, "report-service"."learners" l
+  LEFT JOIN grouped_answers
+  ON l.run_remote_endpoint = grouped_answers.remote_endpoint
+  WHERE l.query_id = '${queryId}' )`
+  : "";
 
   let headerRowUnion = "";
   let groupedSubSelect;
@@ -234,12 +253,11 @@ exports.generateSQL = (queryId, resource, denormalizedResource, usageReport, run
       {name: "num_questions",
        value: "activities.num_questions"},
       {name: "num_answers",
-       value: "cardinality(array_intersect(map_keys(kv1),map_keys(activities.questions)))"},
+       value: "num_answers"},
       {name: "percent_complete",
-       value: "round(100.0 * cardinality(array_intersect(map_keys(kv1),map_keys(activities.questions))) / activities.num_questions, 1)"}
+       value: "round(100.0 * num_answers / activities.num_questions, 1)"}
     ]
     allColumns.push(...completionColumns);
-    escapedUrl = resource.url.replace(/[^a-z0-9]/g, "-");
 
     if (!usageReport) {
       const questionsColumns = [];
@@ -264,21 +282,20 @@ UNION ALL
 `;
     }
 
-    const answerMaps = `map_agg(a.question_id, a.answer) kv1, map_agg(a.question_id, a.submitted) submitted`;
+    // const answerMaps = `map_agg(a.question_id, a.answer) kv1, map_agg(a.question_id, a.submitted) submitted`;
 
-    groupedSubSelect = `SELECT ${groupingSelect}, ${answerMaps}
-    FROM "report-service"."partitioned_answers" a
-    INNER JOIN "report-service"."learners" l
-    ON (l.query_id = '${queryId}' AND l.run_remote_endpoint = a.remote_endpoint)
-    WHERE a.escaped_url = '${escapedUrl}'
-    GROUP BY l.run_remote_endpoint`;
+    // groupedSubSelect = `SELECT ${groupingSelect}, ${answerMaps}
+    // FROM "report-service"."partitioned_answers" a
+    // INNER JOIN "report-service"."learners" l
+    // ON (l.query_id = '${queryId}' AND l.run_remote_endpoint = a.remote_endpoint)
+    // WHERE a.escaped_url = '${escapedUrl}'
+    // GROUP BY l.run_remote_endpoint`;
   } else {
-    escapedUrl = runnableUrl.replace(/[^a-z0-9]/g, "-");
-
-    groupedSubSelect = `SELECT ${groupingSelect}
+    groupedSubSelect = `
+  ( SELECT ${groupingSelect}
     FROM "report-service"."learners" l
     WHERE l.query_id = '${queryId}'
-    GROUP BY l.run_remote_endpoint`;
+    GROUP BY l.run_remote_endpoint )`;
   }
 
   const mainSelect = allColumns.map(selectFromColumn).join(",\n  ");
@@ -286,12 +303,15 @@ UNION ALL
   return `-- name ${hasResource ? resource.name : runnableUrl}
 -- type ${hasResource ? resource.type : "assignment"}
 
-${hasResource ? `WITH activities AS ( SELECT *, cardinality(questions) AS num_questions FROM "report-service"."activity_structure" WHERE structure_id = '${queryId}' )` : ""}
+${hasResource ? `WITH activities AS ( SELECT *, cardinality(questions) AS num_questions FROM "report-service"."activity_structure" WHERE structure_id = '${queryId}' ),` : ""}
+
+${groupedAnswers}
+
+${learnersAndAnswers}
 ${headerRowUnion}
 SELECT
   ${mainSelect}
-FROM${hasResource ? ` activities,` : ""}
-  ( ${groupedSubSelect} )`
+FROM${hasResource ? ` activities, learners_and_answers` : groupedSubSelect}`
 }
 
 /*

--- a/query-creator/create-query/steps/aws.js
+++ b/query-creator/create-query/steps/aws.js
@@ -230,7 +230,8 @@ exports.generateSQL = (queryId, resource, denormalizedResource, usageReport, run
   const groupingSelect = `l.run_remote_endpoint remote_endpoint, ${groupingSelectMetadataColumns}, ${assignTeacherVar}`
   const answerMaps = `map_agg(a.question_id, a.answer) kv1, map_agg(a.question_id, a.submitted) submitted`;
 
-  const groupedAnswers = hasResource ? `grouped_answers AS ( SELECT l.run_remote_endpoint remote_endpoint, ${answerMaps}
+  const groupedAnswers = hasResource ? `
+grouped_answers AS ( SELECT l.run_remote_endpoint remote_endpoint, ${answerMaps}
   FROM "report-service"."partitioned_answers" a
   INNER JOIN "report-service"."learners" l
   ON (l.query_id = '${queryId}' AND l.run_remote_endpoint = a.remote_endpoint)
@@ -238,7 +239,8 @@ exports.generateSQL = (queryId, resource, denormalizedResource, usageReport, run
   GROUP BY l.run_remote_endpoint ),`
   : "";
 
-  const learnersAndAnswers = hasResource ? `learners_and_answers AS ( SELECT run_remote_endpoint remote_endpoint, runnable_url, learner_id, student_id, user_id, student_name, username, school, class, class_id, permission_forms, last_run, teachers, grouped_answers.kv1 kv1, grouped_answers.submitted submitted,
+  const learnersAndAnswers = hasResource ? `
+learners_and_answers AS ( SELECT run_remote_endpoint remote_endpoint, runnable_url, learner_id, student_id, user_id, student_name, username, school, class, class_id, permission_forms, last_run, teachers, grouped_answers.kv1 kv1, grouped_answers.submitted submitted,
   IF (kv1 is null, 0, cardinality(array_intersect(map_keys(kv1),map_keys(activities.questions)))) num_answers
   FROM activities, "report-service"."learners" l
   LEFT JOIN grouped_answers
@@ -296,9 +298,7 @@ UNION ALL
 -- type ${hasResource ? resource.type : "assignment"}
 
 ${hasResource ? `WITH activities AS ( SELECT *, cardinality(questions) AS num_questions FROM "report-service"."activity_structure" WHERE structure_id = '${queryId}' ),` : ""}
-
 ${groupedAnswers}
-
 ${learnersAndAnswers}
 ${headerRowUnion}
 SELECT

--- a/query-creator/create-query/tests/unit/test-handler.js
+++ b/query-creator/create-query/tests/unit/test-handler.js
@@ -70,7 +70,21 @@ describe('Query creation', function () {
         const expectedSQLresult = `-- name test activity
 -- type activity
 
-WITH activities AS ( SELECT *, cardinality(questions) AS num_questions FROM "report-service"."activity_structure" WHERE structure_id = '123456789' )
+WITH activities AS ( SELECT *, cardinality(questions) AS num_questions FROM "report-service"."activity_structure" WHERE structure_id = '123456789' ),
+
+grouped_answers AS ( SELECT l.run_remote_endpoint remote_endpoint, map_agg(a.question_id, a.answer) kv1, map_agg(a.question_id, a.submitted) submitted
+  FROM "report-service"."partitioned_answers" a
+  INNER JOIN "report-service"."learners" l
+  ON (l.query_id = '123456789' AND l.run_remote_endpoint = a.remote_endpoint)
+  WHERE a.escaped_url = 'https---authoring-staging-concord-org-activities-000000'
+  GROUP BY l.run_remote_endpoint ),
+
+learners_and_answers AS ( SELECT run_remote_endpoint remote_endpoint, runnable_url, learner_id, student_id, user_id, student_name, username, school, class, class_id, permission_forms, last_run, teachers, grouped_answers.kv1 kv1, grouped_answers.submitted submitted,
+  IF (kv1 is null, 0, cardinality(array_intersect(map_keys(kv1),map_keys(activities.questions)))) num_answers
+  FROM activities, "report-service"."learners" l
+  LEFT JOIN grouped_answers
+  ON l.run_remote_endpoint = grouped_answers.remote_endpoint
+  WHERE l.query_id = '123456789' )
 
 SELECT
   null AS remote_endpoint,
@@ -138,8 +152,8 @@ SELECT
   array_join(transform(teachers, teacher -> teacher.state), ',') AS teacher_states,
   array_join(transform(teachers, teacher -> teacher.email), ',') AS teacher_emails,
   activities.num_questions AS num_questions,
-  cardinality(array_intersect(map_keys(kv1),map_keys(activities.questions))) AS num_answers,
-  round(100.0 * cardinality(array_intersect(map_keys(kv1),map_keys(activities.questions))) / activities.num_questions, 1) AS percent_complete,
+  num_answers,
+  round(100.0 * num_answers / activities.num_questions, 1) AS percent_complete,
   array_join(transform(CAST(json_extract(kv1['multiple_choice_00000'],'$.choice_ids') AS ARRAY(VARCHAR)), x -> CONCAT(activities.choices['multiple_choice_00000'][x].content, IF(activities.choices['multiple_choice_00000'][x].correct,' (correct)',' (wrong)'))),', ') AS multiple_choice_00000_choice,
   array_join(transform(CAST(json_extract(kv1['multiple_choice_01000'],'$.choice_ids') AS ARRAY(VARCHAR)), x -> CONCAT(activities.choices['multiple_choice_01000'][x].content, '')),', ') AS multiple_choice_01000_choice,
   array_join(transform(CAST(json_extract(kv1['multiple_choice_02000'],'$.choice_ids') AS ARRAY(VARCHAR)), x -> CONCAT(activities.choices['multiple_choice_02000'][x].content, IF(activities.choices['multiple_choice_02000'][x].correct,' (correct)',' (wrong)'))),', ') AS multiple_choice_02000_choice,
@@ -162,13 +176,7 @@ SELECT
   kv1['managed_interactive_77777'] AS managed_interactive_77777_answer,
   kv1['managed_interactive_88888'] AS managed_interactive_88888_json,
   kv1['managed_interactive_99999'] AS managed_interactive_99999_json
-FROM activities,
-  ( SELECT l.run_remote_endpoint remote_endpoint, arbitrary(l.runnable_url) AS runnable_url, arbitrary(l.learner_id) AS learner_id, arbitrary(l.student_id) AS student_id, arbitrary(l.user_id) AS user_id, arbitrary(l.student_name) AS student_name, arbitrary(l.username) AS username, arbitrary(l.school) AS school, arbitrary(l.class) AS class, arbitrary(l.class_id) AS class_id, arbitrary(l.permission_forms) AS permission_forms, arbitrary(l.last_run) AS last_run, arbitrary(l.teachers) teachers, map_agg(a.question_id, a.answer) kv1, map_agg(a.question_id, a.submitted) submitted
-    FROM "report-service"."partitioned_answers" a
-    INNER JOIN "report-service"."learners" l
-    ON (l.query_id = '123456789' AND l.run_remote_endpoint = a.remote_endpoint)
-    WHERE a.escaped_url = 'https---authoring-staging-concord-org-activities-000000'
-    GROUP BY l.run_remote_endpoint )`;
+FROM activities, learners_and_answers`;
 
         const untabbedGeneratedSQLresult = generatedSQLresult.replace("\t", "");
         const untabbedExpectedSQLresult = expectedSQLresult.replace("\t", "");
@@ -183,7 +191,22 @@ describe('Query creation usage report', function () {
       const expectedSQLresult = `-- name test activity
 -- type activity
 
-WITH activities AS ( SELECT *, cardinality(questions) AS num_questions FROM "report-service"."activity_structure" WHERE structure_id = '123456789' )
+WITH activities AS ( SELECT *, cardinality(questions) AS num_questions FROM "report-service"."activity_structure" WHERE structure_id = '123456789' ),
+
+grouped_answers AS ( SELECT l.run_remote_endpoint remote_endpoint, map_agg(a.question_id, a.answer) kv1, map_agg(a.question_id, a.submitted) submitted
+  FROM "report-service"."partitioned_answers" a
+  INNER JOIN "report-service"."learners" l
+  ON (l.query_id = '123456789' AND l.run_remote_endpoint = a.remote_endpoint)
+  WHERE a.escaped_url = 'https---authoring-staging-concord-org-activities-000000'
+  GROUP BY l.run_remote_endpoint ),
+
+learners_and_answers AS ( SELECT run_remote_endpoint remote_endpoint, runnable_url, learner_id, student_id, user_id, student_name, username, school, class, class_id, permission_forms, last_run, teachers, grouped_answers.kv1 kv1, grouped_answers.submitted submitted,
+  IF (kv1 is null, 0, cardinality(array_intersect(map_keys(kv1),map_keys(activities.questions)))) num_answers
+  FROM activities, "report-service"."learners" l
+  LEFT JOIN grouped_answers
+  ON l.run_remote_endpoint = grouped_answers.remote_endpoint
+  WHERE l.query_id = '123456789' )\
+
 
 SELECT
   remote_endpoint,
@@ -204,15 +227,9 @@ SELECT
   array_join(transform(teachers, teacher -> teacher.state), ',') AS teacher_states,
   array_join(transform(teachers, teacher -> teacher.email), ',') AS teacher_emails,
   activities.num_questions AS num_questions,
-  cardinality(array_intersect(map_keys(kv1),map_keys(activities.questions))) AS num_answers,
-  round(100.0 * cardinality(array_intersect(map_keys(kv1),map_keys(activities.questions))) / activities.num_questions, 1) AS percent_complete
-FROM activities,
-  ( SELECT l.run_remote_endpoint remote_endpoint, arbitrary(l.runnable_url) AS runnable_url, arbitrary(l.learner_id) AS learner_id, arbitrary(l.student_id) AS student_id, arbitrary(l.user_id) AS user_id, arbitrary(l.student_name) AS student_name, arbitrary(l.username) AS username, arbitrary(l.school) AS school, arbitrary(l.class) AS class, arbitrary(l.class_id) AS class_id, arbitrary(l.permission_forms) AS permission_forms, arbitrary(l.last_run) AS last_run, arbitrary(l.teachers) teachers, map_agg(a.question_id, a.answer) kv1, map_agg(a.question_id, a.submitted) submitted
-    FROM "report-service"."partitioned_answers" a
-    INNER JOIN "report-service"."learners" l
-    ON (l.query_id = '123456789' AND l.run_remote_endpoint = a.remote_endpoint)
-    WHERE a.escaped_url = 'https---authoring-staging-concord-org-activities-000000'
-    GROUP BY l.run_remote_endpoint )`;
+  num_answers,
+  round(100.0 * num_answers / activities.num_questions, 1) AS percent_complete
+FROM activities, learners_and_answers`;
 
       const untabbedGeneratedSQLresult = generatedSQLresult.replace("\t", "");
       const untabbedExpectedSQLresult = expectedSQLresult.replace("\t", "");
@@ -220,13 +237,15 @@ FROM activities,
   });
 });
 
-
-
 describe('Query creation unreportable runnable', function () {
   it('verifies successful query creation of unreportable runnable', async () => {
       const generatedSQLresult = await aws.generateSQL(testQueryId, undefined, undefined, false, "www.test.url");
       const expectedSQLresult = `-- name www.test.url
 -- type assignment
+
+
+
+
 
 
 

--- a/query-creator/create-query/tests/unit/test-handler.js
+++ b/query-creator/create-query/tests/unit/test-handler.js
@@ -247,8 +247,6 @@ describe('Query creation unreportable runnable', function () {
 
 
 
-
-
 SELECT
   remote_endpoint,
   runnable_url,


### PR DESCRIPTION
This PR adjust the Athena SQL query in `generateSQL` so that it can handle learners who we do not have answer data for.  This is based off of the query presented by @scytacki on Slack.  A few things that still merit testing or improving:
- in some of the queries there are excess line breaks (not sure if we care)
- probably should be tested more with real data before merging (the queries work, but I haven't set up the staging case yet where we have users who don't have answers so we can ensure that they appear in the report).