### PR TITLE
Add model urls to Athena query

### DIFF
--- a/query-creator/README.md
+++ b/query-creator/README.md
@@ -77,7 +77,7 @@ Or the `QueryCreatorLocalTestUser` credential information can be configured via 
 query-creator$ aws configure
 ```
 
-The following environment variables need to be configured: `OutputBucket`, `ReportServiceToken`, `ReportServiceUrl`. These can be configured system-wide or as default values in the `parameters` section of `template.yml`. For example, `OutputBucket` can be configured as follows:
+The following environment variables need to be configured: `OutputBucket`, `ReportServiceToken`, `ReportServiceUrl`, `FirebaseApp`. These can be configured system-wide or as default values in the `parameters` section of `template.yml`. For example, `OutputBucket` can be configured as follows:
 ```
   OutputBucket:
     Type: String

--- a/query-creator/README.md
+++ b/query-creator/README.md
@@ -210,6 +210,7 @@ Next, you can use AWS Serverless Application Repository to deploy ready to use A
       class string,
       school string,
       user_id string,
+      offering_id string,
       permission_forms string,
       username string,
       student_name string,

--- a/query-creator/create-query/app.js
+++ b/query-creator/create-query/app.js
@@ -47,22 +47,6 @@ exports.lambdaHandler = async (event, context) => {
 
     const queryIdsPerRunnable = await aws.fetchAndUploadLearnerData(jwt, query, learnersApiUrl);
 
-    const createModelUrl = (modelId) => {
-      return [`concat(`,
-        `'https://portal-report.concord.org/branch/master/index.html`,
-        `?auth-domain=${encodeURIComponent(authDomain)}`,
-        `&firebase-app=${process.env.FIREBASE_APP}`,
-        `&iframeQuestionId=${modelId}`,
-        `&class=${encodeURIComponent(`${authDomain}/api/v1/classes/`)}',`,
-        ` cast(class_id as varchar), `,
-        `'&offering=${encodeURIComponent(`${authDomain}/api/v1/offerings/`)}',`,
-        ` cast(offering_id as varchar), `,
-        `'&studentId=',`,
-        ` cast(user_id as varchar)`,
-        `)`
-      ].join("");
-    }
-
     const sqlOutput = [];
 
     for (const runnableUrl in queryIdsPerRunnable) {
@@ -83,7 +67,7 @@ exports.lambdaHandler = async (event, context) => {
       }
 
       // generate the sql for the query
-      const sql = aws.generateSQL(queryId, resource, denormalizedResource, usageReport, runnableUrl, createModelUrl);
+      const sql = aws.generateSQL(queryId, resource, denormalizedResource, usageReport, runnableUrl, authDomain);
 
       if (debugSQL) {
         sqlOutput.push(`${resource ? `-- id ${resource.id}` : `-- url ${runnableUrl}`}\n${sql}`);

--- a/query-creator/create-query/tests/unit/test-handler.js
+++ b/query-creator/create-query/tests/unit/test-handler.js
@@ -7,7 +7,8 @@ const chai = require('chai');
 const expect = chai.expect;
 var event, context;
 
-const createModelUrl = () => "model-url";
+process.env.FIREBASE_APP = 'report-service-test';
+process.env.PORTAL_REPORT_URL = 'https://portal-report.test'
 
 const testQueryId = "123456789";
 const testResource = {
@@ -68,7 +69,7 @@ describe('Tests index', function () {
 describe('Query creation', function () {
     it('verifies successful query creation', async () => {
         const testDenormalizedResource = firebase.denormalizeResource(testResource);
-        const generatedSQLresult = await aws.generateSQL(testQueryId, testResource, testDenormalizedResource, false, "", createModelUrl);
+        const generatedSQLresult = await aws.generateSQL(testQueryId, testResource, testDenormalizedResource, false, "", "fake-auth-domain");
         const expectedSQLresult = `-- name test activity
 -- type activity
 
@@ -178,7 +179,7 @@ SELECT
   json_extract_scalar(kv1['managed_interactive_77777'], '$.text') AS managed_interactive_77777_text,
   kv1['managed_interactive_77777'] AS managed_interactive_77777_answer,
   kv1['managed_interactive_88888'] AS managed_interactive_88888_json,
-  CASE WHEN kv1['managed_interactive_88888'] IS NULL THEN '' ELSE model-url END AS managed_interactive_88888_url,
+  CASE WHEN kv1['managed_interactive_88888'] IS NULL THEN '' ELSE CONCAT('https://portal-report.test?auth-domain=fake-auth-domain&firebase-app=report-service-test&iframeQuestionId=managed_interactive_88888&class=fake-auth-domain%2Fapi%2Fv1%2Fclasses%2F', CAST(class_id AS VARCHAR), '&offering=fake-auth-domain%2Fapi%2Fv1%2Fofferings%2F', CAST(offering_id AS VARCHAR), '&studentId=', CAST(user_id AS VARCHAR)) END AS managed_interactive_88888_url,
   kv1['managed_interactive_99999'] AS managed_interactive_99999_json
 FROM activities, learners_and_answers`;
 
@@ -191,7 +192,7 @@ FROM activities, learners_and_answers`;
 describe('Query creation usage report', function () {
   it('verifies successful query creation in usage report mode', async () => {
       const testDenormalizedResource = firebase.denormalizeResource(testResource);
-      const generatedSQLresult = await aws.generateSQL(testQueryId, testResource, testDenormalizedResource, true, "", createModelUrl);
+      const generatedSQLresult = await aws.generateSQL(testQueryId, testResource, testDenormalizedResource, true, "", "fake-auth-domain");
       const expectedSQLresult = `-- name test activity
 -- type activity
 
@@ -243,7 +244,7 @@ FROM activities, learners_and_answers`;
 
 describe('Query creation unreportable runnable', function () {
   it('verifies successful query creation of unreportable runnable', async () => {
-      const generatedSQLresult = await aws.generateSQL(testQueryId, undefined, undefined, false, "www.test.url", createModelUrl);
+      const generatedSQLresult = await aws.generateSQL(testQueryId, undefined, undefined, false, "www.test.url", "fake-auth-domain");
       const expectedSQLresult = `-- name www.test.url
 -- type assignment
 

--- a/query-creator/create-query/tests/unit/test-handler.js
+++ b/query-creator/create-query/tests/unit/test-handler.js
@@ -7,6 +7,8 @@ const chai = require('chai');
 const expect = chai.expect;
 var event, context;
 
+const createModelUrl = () => "model-url";
+
 const testQueryId = "123456789";
 const testResource = {
   url: "https://authoring.staging.concord.org/activities/000000",
@@ -66,7 +68,7 @@ describe('Tests index', function () {
 describe('Query creation', function () {
     it('verifies successful query creation', async () => {
         const testDenormalizedResource = firebase.denormalizeResource(testResource);
-        const generatedSQLresult = await aws.generateSQL(testQueryId, testResource, testDenormalizedResource, false);
+        const generatedSQLresult = await aws.generateSQL(testQueryId, testResource, testDenormalizedResource, false, "", createModelUrl);
         const expectedSQLresult = `-- name test activity
 -- type activity
 
@@ -79,7 +81,7 @@ grouped_answers AS ( SELECT l.run_remote_endpoint remote_endpoint, map_agg(a.que
   WHERE a.escaped_url = 'https---authoring-staging-concord-org-activities-000000'
   GROUP BY l.run_remote_endpoint ),
 
-learners_and_answers AS ( SELECT run_remote_endpoint remote_endpoint, runnable_url, learner_id, student_id, user_id, student_name, username, school, class, class_id, permission_forms, last_run, teachers, grouped_answers.kv1 kv1, grouped_answers.submitted submitted,
+learners_and_answers AS ( SELECT run_remote_endpoint remote_endpoint, runnable_url, learner_id, student_id, user_id, offering_id, student_name, username, school, class, class_id, permission_forms, last_run, teachers, grouped_answers.kv1 kv1, grouped_answers.submitted submitted,
   IF (kv1 is null, 0, cardinality(array_intersect(map_keys(kv1),map_keys(activities.questions)))) num_answers
   FROM activities, "report-service"."learners" l
   LEFT JOIN grouped_answers
@@ -128,6 +130,7 @@ SELECT
   null AS managed_interactive_77777_text,
   null AS managed_interactive_77777_answer,
   null AS managed_interactive_88888_json,
+  null AS managed_interactive_88888_url,
   null AS managed_interactive_99999_json
 FROM activities
 
@@ -175,6 +178,7 @@ SELECT
   json_extract_scalar(kv1['managed_interactive_77777'], '$.text') AS managed_interactive_77777_text,
   kv1['managed_interactive_77777'] AS managed_interactive_77777_answer,
   kv1['managed_interactive_88888'] AS managed_interactive_88888_json,
+  CASE WHEN kv1['managed_interactive_88888'] IS NULL THEN '' ELSE model-url END AS managed_interactive_88888_url,
   kv1['managed_interactive_99999'] AS managed_interactive_99999_json
 FROM activities, learners_and_answers`;
 
@@ -187,7 +191,7 @@ FROM activities, learners_and_answers`;
 describe('Query creation usage report', function () {
   it('verifies successful query creation in usage report mode', async () => {
       const testDenormalizedResource = firebase.denormalizeResource(testResource);
-      const generatedSQLresult = await aws.generateSQL(testQueryId, testResource, testDenormalizedResource, true);
+      const generatedSQLresult = await aws.generateSQL(testQueryId, testResource, testDenormalizedResource, true, "", createModelUrl);
       const expectedSQLresult = `-- name test activity
 -- type activity
 
@@ -200,7 +204,7 @@ grouped_answers AS ( SELECT l.run_remote_endpoint remote_endpoint, map_agg(a.que
   WHERE a.escaped_url = 'https---authoring-staging-concord-org-activities-000000'
   GROUP BY l.run_remote_endpoint ),
 
-learners_and_answers AS ( SELECT run_remote_endpoint remote_endpoint, runnable_url, learner_id, student_id, user_id, student_name, username, school, class, class_id, permission_forms, last_run, teachers, grouped_answers.kv1 kv1, grouped_answers.submitted submitted,
+learners_and_answers AS ( SELECT run_remote_endpoint remote_endpoint, runnable_url, learner_id, student_id, user_id, offering_id, student_name, username, school, class, class_id, permission_forms, last_run, teachers, grouped_answers.kv1 kv1, grouped_answers.submitted submitted,
   IF (kv1 is null, 0, cardinality(array_intersect(map_keys(kv1),map_keys(activities.questions)))) num_answers
   FROM activities, "report-service"."learners" l
   LEFT JOIN grouped_answers
@@ -239,7 +243,7 @@ FROM activities, learners_and_answers`;
 
 describe('Query creation unreportable runnable', function () {
   it('verifies successful query creation of unreportable runnable', async () => {
-      const generatedSQLresult = await aws.generateSQL(testQueryId, undefined, undefined, false, "www.test.url");
+      const generatedSQLresult = await aws.generateSQL(testQueryId, undefined, undefined, false, "www.test.url", createModelUrl);
       const expectedSQLresult = `-- name www.test.url
 -- type assignment
 

--- a/query-creator/env.sample.json
+++ b/query-creator/env.sample.json
@@ -2,6 +2,8 @@
   "Parameters": {
     "OUTPUT_BUCKET": "concordqa-report-data",
     "REPORT_SERVICE_TOKEN": "replace_me_with_the_real_report_service_dev_token",
-    "REPORT_SERVICE_URL": "https://us-central1-report-service-dev.cloudfunctions.net/api"
+    "REPORT_SERVICE_URL": "https://us-central1-report-service-dev.cloudfunctions.net/api",
+    "POTAL_REPORT_URL": "https://portal-report.concord.org/branch/master/index.html",
+    "FIREBASE_APP": "report-service-dev"
   }
 }

--- a/query-creator/samconfig.toml
+++ b/query-creator/samconfig.toml
@@ -9,7 +9,7 @@ s3_prefix = "report-service-query-creator"
 region = "us-east-1"
 confirm_changeset = true
 capabilities = "CAPABILITY_IAM"
-parameter_overrides = "OutputBucket=\"concordqa-report-data\" ReportServiceUrl=\"https://us-central1-report-service-dev.cloudfunctions.net/api\" ResearcherReportsUrl=\"https://researcher-reports.concord.org/branch/master/\""
+parameter_overrides = "OutputBucket=\"concordqa-report-data\" FirebaseApp=\"report-service-dev\" ReportServiceUrl=\"https://us-central1-report-service-dev.cloudfunctions.net/api\" ResearcherReportsUrl=\"https://researcher-reports.concord.org/branch/master/\""
 
 [production]
 [production.deploy]
@@ -20,7 +20,7 @@ s3_prefix = "report-service-query-creator"
 region = "us-east-1"
 confirm_changeset = true
 capabilities = "CAPABILITY_IAM"
-parameter_overrides = "OutputBucket=\"concord-report-data\" ReportServiceUrl=\"https://us-central1-report-service-pro.cloudfunctions.net/api\" ResearcherReportsUrl=\"https://researcher-reports.concord.org/\""
+parameter_overrides = "OutputBucket=\"concord-report-data\" FirebaseApp=\"report-service-pro\" ReportServiceUrl=\"https://us-central1-report-service-pro.cloudfunctions.net/api\" ResearcherReportsUrl=\"https://researcher-reports.concord.org/\""
 
 [default.local_start_api.parameters]
 profile = "QueryCreatorLocalTestUser"

--- a/query-creator/samconfig.toml
+++ b/query-creator/samconfig.toml
@@ -9,7 +9,7 @@ s3_prefix = "report-service-query-creator"
 region = "us-east-1"
 confirm_changeset = true
 capabilities = "CAPABILITY_IAM"
-parameter_overrides = "OutputBucket=\"concordqa-report-data\" FirebaseApp=\"report-service-dev\" ReportServiceUrl=\"https://us-central1-report-service-dev.cloudfunctions.net/api\" ResearcherReportsUrl=\"https://researcher-reports.concord.org/branch/master/\""
+parameter_overrides = "OutputBucket=\"concordqa-report-data\" FirebaseApp=\"report-service-dev\" PortalReportUrl=\"https://portal-report.concord.org/branch/master/index.html\" ReportServiceUrl=\"https://us-central1-report-service-dev.cloudfunctions.net/api\" ResearcherReportsUrl=\"https://researcher-reports.concord.org/branch/master/\""
 
 [production]
 [production.deploy]
@@ -20,7 +20,7 @@ s3_prefix = "report-service-query-creator"
 region = "us-east-1"
 confirm_changeset = true
 capabilities = "CAPABILITY_IAM"
-parameter_overrides = "OutputBucket=\"concord-report-data\" FirebaseApp=\"report-service-pro\" ReportServiceUrl=\"https://us-central1-report-service-pro.cloudfunctions.net/api\" ResearcherReportsUrl=\"https://researcher-reports.concord.org/\""
+parameter_overrides = "OutputBucket=\"concord-report-data\" FirebaseApp=\"report-service-pro\" PortalReportUrl=\"https://portal-report.concord.org/branch/master/index.html\" ReportServiceUrl=\"https://us-central1-report-service-pro.cloudfunctions.net/api\" ResearcherReportsUrl=\"https://researcher-reports.concord.org/\""
 
 [default.local_start_api.parameters]
 profile = "QueryCreatorLocalTestUser"

--- a/query-creator/template.yaml
+++ b/query-creator/template.yaml
@@ -17,6 +17,9 @@ Parameters:
     Type: String
     Description: URL for researcher reports app
     Default: https://localhost:8080
+  FirebaseApp:
+    Type: String
+    Description: Firebase app name
 
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
@@ -28,6 +31,7 @@ Globals:
         REPORT_SERVICE_TOKEN: !Ref ReportServiceToken
         REPORT_SERVICE_URL: !Ref ReportServiceUrl
         RESEARCHER_REPORTS_URL: !Ref ResearcherReportsUrl
+        FIREBASE_APP: !Ref FirebaseApp
 
 Resources:
   CreateQueryFunction:

--- a/query-creator/template.yaml
+++ b/query-creator/template.yaml
@@ -20,6 +20,9 @@ Parameters:
   FirebaseApp:
     Type: String
     Description: Firebase app name
+  PortalReportUrl:
+    Type: String
+    Description: Url to the Portal Report where reseachers can load learner's models
 
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
@@ -32,6 +35,7 @@ Globals:
         REPORT_SERVICE_URL: !Ref ReportServiceUrl
         RESEARCHER_REPORTS_URL: !Ref ResearcherReportsUrl
         FIREBASE_APP: !Ref FirebaseApp
+        PORTAL_REPORT_URL: !Ref PortalReportUrl
 
 Resources:
   CreateQueryFunction:


### PR DESCRIPTION
This constructs a url to the Portal Report for every iframe interactive, if the user has answer data for the model.

The url that is constructed looks like:

```
https://portal-report.concord.org/branch/master/index.html
  ?auth-domain=[https://learn.staging.concord.org | https://learn.concord.org | other portal url]
  &firebase-app=[report-service-dev | report-service-pro]
  &iframeQuestionId=[model-id, eg. "mw_interactive_210741"]
  &class=[{portal-url}/api/v1/classes/{class-id}]
  &offering=[{portal-url}/api/v1/offerings/{offering-id}]
  &studentId=[student-id]
```

For this to work we need the `offering-id`, which wasn't previously passed back from the portal when requesting learner details, and has now been added as a PR. The leaners table must also be updated to support this.

An example query that can be run in Athena as `AdminConcordQA` is

```
-- id activity-activity_20811
-- name Sam's GeoCode test
-- type activity

WITH activities AS ( SELECT *, cardinality(questions) AS num_questions FROM "report-service"."activity_structure" WHERE structure_id = 'f6363e70-c366-4e02-82db-0b42fc9853f4' ),

grouped_answers AS ( SELECT l.run_remote_endpoint remote_endpoint, map_agg(a.question_id, a.answer) kv1, map_agg(a.question_id, a.submitted) submitted
  FROM "report-service"."partitioned_answers" a
  INNER JOIN "report-service"."learners" l
  ON (l.query_id = 'f6363e70-c366-4e02-82db-0b42fc9853f4' AND l.run_remote_endpoint = a.remote_endpoint)
  WHERE a.escaped_url = 'https---authoring-staging-concord-org-activities-20811'
  GROUP BY l.run_remote_endpoint ),

learners_and_answers AS ( SELECT run_remote_endpoint remote_endpoint, runnable_url, learner_id, student_id, user_id, offering_id, student_name, username, school, class, class_id, permission_forms, last_run, teachers, grouped_answers.kv1 kv1, grouped_answers.submitted submitted,
  IF (kv1 is null, 0, cardinality(array_intersect(map_keys(kv1),map_keys(activities.questions)))) num_answers
  FROM activities, "report-service"."learners" l
  LEFT JOIN grouped_answers
  ON l.run_remote_endpoint = grouped_answers.remote_endpoint
  WHERE l.query_id = 'f6363e70-c366-4e02-82db-0b42fc9853f4' )

SELECT
  null AS remote_endpoint,
  null AS runnable_url,
  null AS learner_id,
  null AS student_id,
  null AS user_id,
  null AS student_name,
  null AS username,
  null AS school,
  null AS class,
  null AS class_id,
  null AS permission_forms,
  null AS last_run,
  null AS teacher_user_ids,
  null AS teacher_names,
  null AS teacher_districts,
  null AS teacher_states,
  null AS teacher_emails,
  null AS num_questions,
  null AS num_answers,
  null AS percent_complete,
  null AS mw_interactive_210741_json,
  null AS mw_interactive_210741_url,
  null AS mw_interactive_210742_json,
  null AS mw_interactive_210742_url
FROM activities

UNION ALL

SELECT
  remote_endpoint,
  runnable_url,
  learner_id,
  student_id,
  user_id,
  student_name,
  username,
  school,
  class,
  class_id,
  permission_forms,
  last_run,
  array_join(transform(teachers, teacher -> teacher.user_id), ',') AS teacher_user_ids,
  array_join(transform(teachers, teacher -> teacher.name), ',') AS teacher_names,
  array_join(transform(teachers, teacher -> teacher.district), ',') AS teacher_districts,
  array_join(transform(teachers, teacher -> teacher.state), ',') AS teacher_states,
  array_join(transform(teachers, teacher -> teacher.email), ',') AS teacher_emails,
  activities.num_questions AS num_questions,
  num_answers,
  round(100.0 * num_answers / activities.num_questions, 1) AS percent_complete,
  kv1['mw_interactive_210741'] AS mw_interactive_210741_json,
  CASE WHEN kv1['mw_interactive_210741'] IS NULL THEN '' ELSE concat('https://portal-report.concord.org/branch/master/index.html?auth-domain=https%3A%2F%2Flearn.staging.concord.org&firebase-app=report-service-dev&iframeQuestionId=mw_interactive_210741&class=https%3A%2F%2Flearn.staging.concord.org%2Fapi%2Fv1%2Fclasses%2F', cast(class_id as varchar), '&offering=https%3A%2F%2Flearn.staging.concord.org%2Fapi%2Fv1%2Fofferings%2F', cast(offering_id as varchar), '&studentId=', cast(user_id as varchar)) END AS mw_interactive_210741_url,
  kv1['mw_interactive_210742'] AS mw_interactive_210742_json,
  CASE WHEN kv1['mw_interactive_210742'] IS NULL THEN '' ELSE concat('https://portal-report.concord.org/branch/master/index.html?auth-domain=https%3A%2F%2Flearn.staging.concord.org&firebase-app=report-service-dev&iframeQuestionId=mw_interactive_210742&class=https%3A%2F%2Flearn.staging.concord.org%2Fapi%2Fv1%2Fclasses%2F', cast(class_id as varchar), '&offering=https%3A%2F%2Flearn.staging.concord.org%2Fapi%2Fv1%2Fofferings%2F', cast(offering_id as varchar), '&studentId=', cast(user_id as varchar)) END AS mw_interactive_210742_url
FROM activities, learners_and_answers
```

This creates two urls for the two learners with models, one of which is

https://portal-report.concord.org/branch/master/index.html?auth-domain=https%3A%2F%2Flearn.staging.concord.org&firebase-app=report-service-dev&iframeQuestionId=mw_interactive_210741&class=https%3A%2F%2Flearn.staging.concord.org%2Fapi%2Fv1%2Fclasses%2F8&offering=https%3A%2F%2Flearn.staging.concord.org%2Fapi%2Fv1%2Fofferings%2F1693&studentId=4652

This requires being logged in as an admin or the class teacher (I believe).

(Note: The query above works because I edited the learner JSON in S3 by hand to include the offering-id. Queries on learn.staging won't otherwise work until the portal PR is brought into staging.)