### PR TITLE
180559584 Athena Log queries are decoupled from learner information.

### DIFF
--- a/query-creator/README.md
+++ b/query-creator/README.md
@@ -155,13 +155,13 @@ While there is probably a much better Docker-ish way to solve this, one hacky so
 
 1. Install [ngrok](https://ngrok.com/), or a similar service to allow you to create a public url for your local servers
 2. Take note of the port that the `app` is running on in your portal Docker UI.
-3. run `npx ngrok https <portarl-app-port-number>` eg: `npx ngrok https 65059` to proxy your docker portal server.
+3. run `npx ngrok https <portal-app-port-number>` eg: `npx ngrok https 65059` to proxy your docker portal server.
 4. Ngrok will tell you on the command line the public URL for your docker server. Copy the https url It should look something like: `https://73bd-162-245-141-223.ngrok.io/`.
 5. Ngrok will also provide a "Web Interface" which allows you to inspect network requests at `http://127.0.0.1:4040/`
 6. You should now log into your local portal using the public https ngrok URL. Its likely Chrome will complain. You should be able to get the browser to load the page, by clicking through all the warnings.
-7. Ensure you have the correct auth-clients, extern-reports, and firebase apps configured for your local portal setup. Here is a partial list of things you should copy from learn.staging:
+7. Ensure you have the correct auth-clients, external-reports, and firebase apps configured for your local portal setup. Here is a partial list of things you should copy from learn.staging:
   1. auth-client: copy the **athena-researcher-reports** `admin/auth-client` from learn.staging.
-  2. Make a new `admins/external_reports` resource. It should use the `DEFAULT_REPORT_SERVICE_CLIENT` auth-client. Its a `researcher-learner` report type. It should `Use Query JWT`. You can try copying the info from an Athena Reports external report from learn.staging.
+  2. Make a new `admins/external_reports` resource. It should use the `DEFAULT_REPORT_SERVICE_CLIENT` auth-client. Its a `researcher-learner` report type. It should `Use Query JWT`. You can try copying the info from an **Athena Reports** external report from learn.staging.
   3. Make a new firebase app by copying the configuration from the **token-service** in learn.staging's `admin/firebase_apps`
 8. Enjoy!
 

--- a/query-creator/README.md
+++ b/query-creator/README.md
@@ -154,9 +154,16 @@ to each other.
 While there is probably a much better Docker-ish way to solve this, one hacky solution is to
 
 1. Install [ngrok](https://ngrok.com/), or a similar service to allow you to create a public url for your local servers
-2. Take note of the port that the app is running on in your Docker UI
-3. Publish that port with ngrok and get back a public url
-4. Hardcode `{public_url}/api/v1/report_learners_es/external_report_learners_from_jwt` in the query-creator app as the `reportServiceUrl`
+2. Take note of the port that the `app` is running on in your portal Docker UI.
+3. run `npx ngrok https <portarl-app-port-number>` eg: `npx ngrok https 65059` to proxy your docker portal server.
+4. Ngrok will tell you on the command line the public URL for your docker server. Copy the https url It should look something like: `https://73bd-162-245-141-223.ngrok.io/`.
+5. Ngrok will also provide a "Web Interface" which allows you to inspect network requests at `http://127.0.0.1:4040/`
+6. You should now log into your local portal using the public https ngrok URL. Its likely Chrome will complain. You should be able to get the browser to load the page, by clicking through all the warnings.
+7. Ensure you have the correct auth-clients, extern-reports, and firebase apps configured for your local portal setup. Here is a partial list of things you should copy from learn.staging:
+  1. auth-client: copy the **athena-researcher-reports** `admin/auth-client` from learn.staging.
+  2. Make a new `admins/external_reports` resource. It should use the `DEFAULT_REPORT_SERVICE_CLIENT` auth-client. Its a `researcher-learner` report type. It should `Use Query JWT`. You can try copying the info from an Athena Reports external report from learn.staging.
+  3. Make a new firebase app by copying the configuration from the **token-service** in learn.staging's `admin/firebase_apps`
+8. Enjoy!
 
 ## Add a resource to your application
 The application template uses AWS Serverless Application Model (AWS SAM) to define application resources. AWS SAM is an extension of AWS CloudFormation with a simpler syntax for configuring common serverless application resources such as functions, triggers, and APIs. For resources not included in [the SAM specification](https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md), you can use standard [AWS CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-template-resource-type-ref.html) resource types.

--- a/query-creator/create-query/app.js
+++ b/query-creator/create-query/app.js
@@ -19,7 +19,7 @@ exports.lambdaHandler = async (event, context) => {
     const tokenServiceEnv = params.tokenServiceEnv;
     const usageReport = params.usageReport || false;
     const useLogs = params.useLogs || false;
-    const endpoint_only = params.endpoint_only || false
+    const endpointOnly = params.endpointOnly || false
 
     if (!reportServiceSource) {
       throw new Error("Missing reportServiceSource in the report url");
@@ -47,7 +47,7 @@ exports.lambdaHandler = async (event, context) => {
     const resource = await tokenService.findOrCreateResource(tokenServiceJwt, tokenServiceEnv, email, portalUrl);
     const workgroupName = await aws.ensureWorkgroup(resource, user);
 
-    const queryIdsPerRunnable = await aws.fetchAndUploadLearnerData(jwt, query, learnersApiUrl, endpoint_only);
+    const queryIdsPerRunnable = await aws.fetchAndUploadLearnerData(jwt, query, learnersApiUrl, endpointOnly);
 
     const sqlOutput = [];
 

--- a/query-creator/create-query/app.js
+++ b/query-creator/create-query/app.js
@@ -19,6 +19,7 @@ exports.lambdaHandler = async (event, context) => {
     const tokenServiceEnv = params.tokenServiceEnv;
     const usageReport = params.usageReport || false;
     const useLogs = params.useLogs || false;
+    const endpoint_only = params.endpoint_only || false
 
     if (!reportServiceSource) {
       throw new Error("Missing reportServiceSource in the report url");
@@ -46,7 +47,7 @@ exports.lambdaHandler = async (event, context) => {
     const resource = await tokenService.findOrCreateResource(tokenServiceJwt, tokenServiceEnv, email, portalUrl);
     const workgroupName = await aws.ensureWorkgroup(resource, user);
 
-    const queryIdsPerRunnable = await aws.fetchAndUploadLearnerData(jwt, query, learnersApiUrl);
+    const queryIdsPerRunnable = await aws.fetchAndUploadLearnerData(jwt, query, learnersApiUrl, endpoint_only);
 
     const sqlOutput = [];
 

--- a/query-creator/create-query/steps/aws.js
+++ b/query-creator/create-query/steps/aws.js
@@ -55,12 +55,12 @@ const uploadLearnerData = async (queryId, learners) => {
  *
  * @returns queryIdsPerRunnable as {[runnable_url]: queryId}
  */
-exports.fetchAndUploadLearnerData = async (jwt, query, learnersApiUrl, endpoint_only=false) => {
+exports.fetchAndUploadLearnerData = async (jwt, query, learnersApiUrl, endpointOnly=false) => {
   const queryIdsPerRunnable = {};     // {[runnable_url]: queryId}
   const queryParams = {
     query,
     page_size: PAGE_SIZE,
-    endpoint_only
+    endpoint_only: endpointOnly
   };
   let foundAllLearners = false;
   while (!foundAllLearners) {

--- a/query-creator/create-query/steps/aws.js
+++ b/query-creator/create-query/steps/aws.js
@@ -55,11 +55,12 @@ const uploadLearnerData = async (queryId, learners) => {
  *
  * @returns queryIdsPerRunnable as {[runnable_url]: queryId}
  */
-exports.fetchAndUploadLearnerData = async (jwt, query, learnersApiUrl) => {
+exports.fetchAndUploadLearnerData = async (jwt, query, learnersApiUrl, endpoint_only=false) => {
   const queryIdsPerRunnable = {};     // {[runnable_url]: queryId}
   const queryParams = {
     query,
-    page_size: PAGE_SIZE
+    page_size: PAGE_SIZE,
+    endpoint_only
   };
   let foundAllLearners = false;
   while (!foundAllLearners) {


### PR DESCRIPTION
## Athena Log queries can be decoupled from learner information:

The goal of this PR is to be able to run learner log queries optionally leaving out learner meta data.

1. 56b9800 : 2021-12-09 :  Update instructions for developing with local docker using ngrok public proxy.

[PT Story #180559584](https://www.pivotaltracker.com/story/show/180559584)