### PR TITLE
180559584 -- limit CSV columns when reporting on log data only.

### DIFF
--- a/query-creator/README.md
+++ b/query-creator/README.md
@@ -212,7 +212,9 @@ You can change the behavior of the query-creator using the following query param
 - `reportServiceSource` : which lara instance to point at. eg: `authoring.staging.concord.org`
 - `tokenServiceEnv` : which token service to use eg: `staging`
 - `useLogs` : run a learner log report for the selected resources. Omit for answer report, set to any value for Log report.
+- `narrowLearners`: For more efficient log reporting: don't reconstitute Learner data (like teachers, classes, &etc)
 - `debugSQL` : don't run the query, just show the generated sql. Omit to run the query, set to any value for SQL debugging.
+
 
 ## AWS Glue/Athena Setup
 

--- a/query-creator/create-query/app.js
+++ b/query-creator/create-query/app.js
@@ -19,7 +19,7 @@ exports.lambdaHandler = async (event, context) => {
     const tokenServiceEnv = params.tokenServiceEnv;
     const usageReport = params.usageReport || false;
     const useLogs = params.useLogs || false;
-    const endpointOnly = params.endpointOnly || false
+    const narrowLearners = params.narrowLearners || false
 
     if (!reportServiceSource) {
       throw new Error("Missing reportServiceSource in the report url");
@@ -47,7 +47,7 @@ exports.lambdaHandler = async (event, context) => {
     const resource = await tokenService.findOrCreateResource(tokenServiceJwt, tokenServiceEnv, email, portalUrl);
     const workgroupName = await aws.ensureWorkgroup(resource, user);
 
-    const queryIdsPerRunnable = await aws.fetchAndUploadLearnerData(jwt, query, learnersApiUrl, endpointOnly);
+    const queryIdsPerRunnable = await aws.fetchAndUploadLearnerData(jwt, query, learnersApiUrl, narrowLearners);
 
     const sqlOutput = [];
 
@@ -83,7 +83,9 @@ exports.lambdaHandler = async (event, context) => {
       const queryId = queryIdsPerRunnable[runnableUrl];
 
       // generate the sql for the query
-      const sql = aws.generateLogSQL(queryId, runnableUrl, authDomain, reportServiceSource);
+      const sql = narrowLearners
+        ? aws.generateNarrowLogSQL(queryId, runnableUrl, authDomain, reportServiceSource)
+        : aws.generateLogSQL(queryId, runnableUrl, authDomain, reportServiceSource);
 
       if (debugSQL) {
         sqlOutput.push(`-- url ${runnableUrl}\n${sql}`);


### PR DESCRIPTION
- Rename query param `endpointOnly` to `narrowLearners`. It makes sense for the portal learner endpoint to use `endpoint_only` for its param, but here that param name seems vague. Renamed for clarity, and updated the docs.

- If the query param `narrowLearners` is true, The select statement will only include `log.*` columns, because we didn't run the reconsituting learner queries. This just reduces empty values in the CSV file that is created.

[#180559584]