### PR TITLE
180969564 : Query-Creator: Database Name param

### DIFF
--- a/query-creator/create-query/steps/aws.js
+++ b/query-creator/create-query/steps/aws.js
@@ -345,11 +345,12 @@ FROM${hasResource ? ` activities, learners_and_answers` : groupedSubSelect}`
 Generates a very wide row including all fields from the log and learner.
 */
 exports.generateLogSQL = (queryId, runnableUrl, authDomain, sourceKey) => {
+  const logDb = process.env.LOG_ATHENA_DB_NAME;
   return `
   -- name ${runnableUrl}
   -- type learner event log ⎯ [qid: ${queryId}]
   SELECT *
-  FROM "log_ingester_qa"."logs_by_time" log
+  FROM "${logDb}"."logs_by_time" log
   INNER JOIN "report-service"."learners" learner
   ON
     (
@@ -364,11 +365,12 @@ exports.generateLogSQL = (queryId, runnableUrl, authDomain, sourceKey) => {
 Generates a smaller row of event details only, no portal info.
 */
 exports.generateNarrowLogSQL = (queryId, runnableUrl, authDomain, sourceKey) => {
+  const logDb = process.env.LOG_ATHENA_DB_NAME;
   return `
   -- name ${runnableUrl}
   -- type learner event log ⎯ [qid: ${queryId}]
   SELECT log.*
-  FROM "log_ingester_qa"."logs_by_time" log
+  FROM "${logDb}"."logs_by_time" log
   INNER JOIN "report-service"."learners" learner
   ON
     (

--- a/query-creator/create-query/steps/env-vars.js
+++ b/query-creator/create-query/steps/env-vars.js
@@ -16,4 +16,7 @@ exports.validate = () => {
   if (!process.env.RESEARCHER_REPORTS_URL) {
     missingVar("RESEARCHER_REPORTS_URL");
   }
+  if (!process.env.LOG_ATHENA_DB_NAME) {
+    missingVar("LOG_ATHENA_DB_NAME");
+  }
 }

--- a/query-creator/env.sample.json
+++ b/query-creator/env.sample.json
@@ -4,6 +4,7 @@
     "REPORT_SERVICE_TOKEN": "replace_me_with_the_real_report_service_dev_token",
     "REPORT_SERVICE_URL": "https://us-central1-report-service-dev.cloudfunctions.net/api",
     "PORTAL_REPORT_URL": "https://portal-report.concord.org/branch/master/index.html",
-    "FIREBASE_APP": "report-service-dev"
+    "FIREBASE_APP": "report-service-dev",
+    "LOG_ATHENA_DB_NAME": "log_ingester_qa"
   }
 }

--- a/query-creator/samconfig.toml
+++ b/query-creator/samconfig.toml
@@ -9,7 +9,7 @@ s3_prefix = "report-service-query-creator"
 region = "us-east-1"
 confirm_changeset = true
 capabilities = "CAPABILITY_IAM"
-parameter_overrides = "OutputBucket=\"concordqa-report-data\" LogInputBucket=\"log-ingester-qa\"  ReportServiceUrl=\"https://us-central1-report-service-dev.cloudfunctions.net/api\" ResearcherReportsUrl=\"https://researcher-reports.concord.org/branch/master/\" FirebaseApp=\"report-service-dev\" PortalReportUrl=\"https://portal-report.concord.org/branch/master/index.html\""
+parameter_overrides = "OutputBucket=\"concordqa-report-data\" LogInputBucket=\"log-ingester-qa\"  ReportServiceUrl=\"https://us-central1-report-service-dev.cloudfunctions.net/api\" ResearcherReportsUrl=\"https://researcher-reports.concord.org/branch/master/\" FirebaseApp=\"report-service-dev\" PortalReportUrl=\"https://portal-report.concord.org/branch/master/index.html\" LogAthenaDBName=\"log_ingester_qa\""
 image_repositories = []
 
 [production]
@@ -21,7 +21,8 @@ s3_prefix = "report-service-query-creator"
 region = "us-east-1"
 confirm_changeset = true
 capabilities = "CAPABILITY_IAM"
-parameter_overrides = "LogInputBucket=\"log-ingester-production\" OutputBucket=\"concord-report-data\" FirebaseApp=\"report-service-pro\" PortalReportUrl=\"https://portal-report.concord.org/branch/master/index.html\" ReportServiceUrl=\"https://us-central1-report-service-pro.cloudfunctions.net/api\" ResearcherReportsUrl=\"https://researcher-reports.concord.org/\""
+parameter_overrides = "OutputBucket=\"concord-report-data\" LogInputBucket=\"log-ingester-production\"  ReportServiceUrl=\"https://us-central1-report-service-pro.cloudfunctions.net/api\" ResearcherReportsUrl=\"https://researcher-reports.concord.org/\" FirebaseApp=\"report-service-pro\" PortalReportUrl=\"https://portal-report.concord.org/branch/master/index.html\" LogAthenaDBName=\"log_ingester_production\""
+image_repositories = []
 
 [default.local_start_api.parameters]
 profile = "QueryCreatorLocalTestUser"

--- a/query-creator/template.yaml
+++ b/query-creator/template.yaml
@@ -26,6 +26,9 @@ Parameters:
   PortalReportUrl:
     Type: String
     Description: Url to the Portal Report where reseachers can load learner's models
+  LogAthenaDBName:
+    Type: String
+    Description: The Athena Database Name
 
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
@@ -39,6 +42,7 @@ Globals:
         RESEARCHER_REPORTS_URL: !Ref ResearcherReportsUrl
         FIREBASE_APP: !Ref FirebaseApp
         PORTAL_REPORT_URL: !Ref PortalReportUrl
+        LOG_ATHENA_DB_NAME: !Ref LogAthenaDBName
 
 Resources:
   CreateQueryFunction:


### PR DESCRIPTION
Query-Creator:
The Log database name changes from staging to production.

We need to put the DB name in an ENV var to be configured in cloud formation.

[#180969564]
https://www.pivotaltracker.com/story/show/180969564

(FWIW this has already been deployed to the production query-creator stack on AWS)