### PR TITLE
Fixed time based user log queries [#184157275]

### DIFF
--- a/query-creator/create-query/steps/aws.js
+++ b/query-creator/create-query/steps/aws.js
@@ -22,9 +22,10 @@ const answerMaps = `map_agg(a.question_id, a.answer) kv1, map_agg(a.question_id,
 
 const escapeSingleQuote = (text) => text.replace(/'/g, "''");
 
-const convertTime = (fromCalendar) => {
+const convertTime = exports.convertTime = (fromCalendar) => {
   const [month, day, year, ...rest] = fromCalendar.split("/");
-  return `${year}-${month}-${day}`;
+  const date = new Date(`${year}-${month}-${day}`);
+  return Math.round(date.getTime() / 1000);
 };
 
 exports.ensureWorkgroup = async (resource, email) => {
@@ -534,10 +535,10 @@ exports.generateUserLogSQL = (usernames, activities, start_date, end_date) => {
     where.push(`log.activity IN (${activities.map(a => `'${escapeSingleQuote(a)}'`).join(", ")})`)
   }
   if (start_date) {
-    where.push(`time >= '${convertTime(start_date)}'`)
+    where.push(`time >= ${convertTime(start_date)}`)
   }
   if (end_date) {
-    where.push(`time <= '${convertTime(end_date)}'`)
+    where.push(`time <= ${convertTime(end_date)}`)
   }
 
   return `

--- a/query-creator/create-query/tests/unit/aws.js
+++ b/query-creator/create-query/tests/unit/aws.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const chai = require('chai');
+const convertTime = require("../../steps/aws").convertTime
+
+const expect = chai.expect;
+describe('AWS', function () {
+  it('converts time from strings to second based unix timestamps', () => {
+    expect(convertTime("01/01/1970")).to.eq(0)
+    expect(convertTime("12/31/2022")).to.eq(1672444800)
+    expect(convertTime("01/01/2023")).to.eq(1672531200)
+    expect(convertTime("01/01/2023") - convertTime("12/31/2022")).to.eq(60 * 60 * 24)
+  });
+});


### PR DESCRIPTION
The time based query was using the old Postgres string date format whereas Athena needed a unix timestamp.