### PR TITLE
fixed: Interpolation dollar signs showing around completion status

### DIFF
--- a/researcher-reports/src/components/query-item.tsx
+++ b/researcher-reports/src/components/query-item.tsx
@@ -143,7 +143,7 @@ export const QueryItem: React.FC<IProps> = (props) => {
             {resourceName && <div className="item-info">{`Name: ${resourceName}`}</div>}
             {resourceType && <div className="item-info">{`Type: ${resourceType}`}</div>}
             <div className="item-info">{`Creation date: ${submissionDateTime}`}</div>
-            <div className="item-info">Completion status: <span className={lowerQueryCompletionStatus}>${lowerQueryCompletionStatus}${completionStatusSuffix}</span></div>
+            <div className="item-info">Completion status: <span className={lowerQueryCompletionStatus}>{lowerQueryCompletionStatus}{completionStatusSuffix}</span></div>
             { showGenerateCSVLinkButton
               ? <button onClick={handleGetSignedDownloadLink} disabled={!succeeded}>Generate CSV Download Link</button>
               : <>


### PR DESCRIPTION
This was a bug introduced during a PR review when the completion status display code was refactored.