### PR TITLE
Added /config endpoint to expose non-secret configuration options

### DIFF
--- a/server/lib/report_server_web/controllers/page_controller.ex
+++ b/server/lib/report_server_web/controllers/page_controller.ex
@@ -1,9 +1,35 @@
 defmodule ReportServerWeb.PageController do
   use ReportServerWeb, :controller
 
+  alias ReportServerWeb.{Auth, TokenService}
+
+
   def home(conn, _params) do
     # The home page is often custom made,
     # so skip the default app layout.
     render(conn, :home, page_title: "Home")
+  end
+
+  def config(conn, _params) do
+    session = get_session(conn)
+    if Auth.logged_in?(session) do
+      portal = Application.get_env(:report_server, :portal) |> Enum.into(%{})
+      token_service = Application.get_env(:report_server, :token_service) |> Enum.into(%{})
+      output = Application.get_env(:report_server, :output) |> Enum.into(%{})
+
+      portal_credentials = Auth.get_portal_credentials(session)
+      {:ok, token_service_env} = TokenService.get_env("prod", portal_credentials)
+
+      config = %{
+        portal: portal,
+        token_service: token_service,
+        output: output,
+        token_service_env: token_service_env,
+        full_token_service_url: TokenService.get_token_service_url(token_service_env)
+      }
+      render(conn, :config, page_title: "Config", config: config, error: nil)
+    else
+      render(conn, :config, page_title: "Config", error: "To get the config you first need to login.")
+    end
   end
 end

--- a/server/lib/report_server_web/controllers/page_html/config.html.heex
+++ b/server/lib/report_server_web/controllers/page_html/config.html.heex
@@ -1,0 +1,14 @@
+<.flash_group flash={@flash} />
+<div class="p-4">
+  <strong>Config Info</strong>
+  <%= if @error do %>
+    <div class="mt-2">
+      <%= @error %>
+    </div>
+
+  <% else %>
+  <div class="whitespace-pre">
+    <%= Jason.encode!(@config, pretty: true) %>
+  </div>
+  <% end %>
+</div>

--- a/server/lib/report_server_web/router.ex
+++ b/server/lib/report_server_web/router.ex
@@ -19,6 +19,7 @@ defmodule ReportServerWeb.Router do
     pipe_through :browser
 
     get "/", PageController, :home
+    get "/config", PageController, :config
 
     get "/auth/login", AuthController, :login
     get "/auth/logout", AuthController, :logout

--- a/server/lib/report_server_web/token_service.ex
+++ b/server/lib/report_server_web/token_service.ex
@@ -24,11 +24,15 @@ defmodule ReportServerWeb.TokenService do
     uri = URI.parse(portal_url)
     # use "production" token service env only if we're on the production url
     # this is the same code ported from the report-service app with the domain updated
-    if uri.host == "report-server.concord.org" && !String.contains?(uri.path, "branch") do
+    if uri.host == "learn.concord.org" && !String.contains?(uri.path || "", "branch") do
       {:ok, "production"}
     else
       {:ok, "staging"}
     end
+  end
+
+  def get_env(_mode,  _portal_credentials) do
+    {:ok, "staging"}
   end
 
   def get_athena_workgroup("demo", _env, _jwt) do
@@ -117,7 +121,7 @@ defmodule ReportServerWeb.TokenService do
   end
   def get_workgroup_credentials_from_response(_), do: {:error, "Something went wrong getting the AWS credentials"}
 
-  defp get_token_service_url(env, path \\ "") do
+  def get_token_service_url(env, path \\ "") do
     url = Application.get_env(:report_server, :token_service)
       |> Keyword.get(:url, "https://token-service-staging.firebaseapp.com/api/v1/resources")
 


### PR DESCRIPTION
I needed to add this to figure out why the production server wasn't walking to the production token service.  You'll see the fix for that in TokenService#get_env.