### PR TITLE
feat: Add portal domain to report-server header

### DIFF
--- a/server/lib/report_server_web/auth.ex
+++ b/server/lib/report_server_web/auth.ex
@@ -25,7 +25,7 @@ defmodule ReportServerWeb.Auth do
   end
 
   def public_session_vars(session) do
-    [logged_in: logged_in?(session)]
+    [logged_in: logged_in?(session), portal_domain: portal_domain(session)]
   end
 
   def save_portal_url(conn) do
@@ -45,5 +45,12 @@ defmodule ReportServerWeb.Auth do
     %{access_token:  access_token, portal_url: portal_url}
   end
   def get_portal_credentials(_), do: nil
+
+  def portal_domain(%{"portal_url" => portal_url}) do
+    portal_url
+    |> URI.parse()
+    |> Map.get(:host)
+  end
+  def portal_domain(_), do: nil
 
 end

--- a/server/lib/report_server_web/components/layouts/app.html.heex
+++ b/server/lib/report_server_web/components/layouts/app.html.heex
@@ -7,7 +7,7 @@
       </a>
     </div>
     <div class="flex items-center gap-4 font-semibold leading-6 text-zinc-900">
-      <.link navigate={~p"/auth/logout"} :if={@logged_in}>Logout</.link>
+      <.link navigate={~p"/auth/logout"} :if={@logged_in}>Logout of <%= @portal_domain %></.link>
       <.link navigate={~p"/auth/login"} :if={!@logged_in}>Login</.link>
     </div>
   </div>


### PR DESCRIPTION
This is to avoid confusion of which portal the user may be logged into.