### PR TITLE
fix: Add report portal urls to production portal url check

### DIFF
--- a/server/lib/report_server_web/components/layouts/app.html.heex
+++ b/server/lib/report_server_web/components/layouts/app.html.heex
@@ -3,7 +3,10 @@
     <div class="flex items-center gap-4">
       <a href="/" class="text-zinc-900 font-bold text-lg flex items-center gap-2">
         <img src={~p"/images/logo.png"} width="36" />
-        Report Server
+        <div>
+          Report Server
+          <div class="text-xs text-gray-500">Version <%= Application.spec(:report_server)[:vsn] %></div>
+        </div>
       </a>
     </div>
     <div class="flex items-center gap-4 font-semibold leading-6 text-zinc-900">

--- a/server/lib/report_server_web/token_service.ex
+++ b/server/lib/report_server_web/token_service.ex
@@ -1,6 +1,8 @@
 defmodule ReportServerWeb.TokenService do
   require Logger
 
+  @production_hosts ["learn.concord.org", "learn-report.concord.org", "ngss-assessment.portal.concord.org", "ngss-assessment-report.portal.concord.org"]
+
   def get_firebase_jwt("demo", _portal_credentials) do
     {:ok, "demo-jwt"}
   end
@@ -22,9 +24,8 @@ defmodule ReportServerWeb.TokenService do
 
   def get_env(_mode, %{portal_url: portal_url} = _portal_credentials) do
     uri = URI.parse(portal_url)
-    # use "production" token service env only if we're on the production url
-    # this is the same code ported from the report-service app with the domain updated
-    if (uri.host == "learn.concord.org" || uri.host == "ngss-assessment.portal.concord.org") && !String.contains?(uri.path || "", "branch") do
+    # use "production" token service env only if we're using a production portal
+    if Enum.any?(@production_hosts, &(&1 == uri.host)) do
       {:ok, "production"}
     else
       {:ok, "staging"}

--- a/server/mix.exs
+++ b/server/mix.exs
@@ -4,7 +4,7 @@ defmodule ReportServer.MixProject do
   def project do
     [
       app: :report_server,
-      version: "1.0.0",
+      version: "1.0.1",
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
The portal parameter generated by the query-creator post uses the report server urls and not the main portal urls.

This also adds the current application version number to the page header to make deployment checks easier.