### PR TITLE
feat: Add api endpoint to get plugin states [PT-187885524]

### DIFF
--- a/functions/src/api/get-plugin-states.ts
+++ b/functions/src/api/get-plugin-states.ts
@@ -1,0 +1,39 @@
+
+import { Request, Response } from "express"
+import { getPath, getCollection } from "./helpers/paths"
+
+export default (req: Request, res: Response) => {
+  const {source, remote_endpoint} = req.query
+
+  if (!source) {
+    return res.error(500, "Missing source in query!")
+  }
+  if (typeof source !== "string") {
+    return res.error(500, "Malformed source")
+  }
+  if (!remote_endpoint) {
+    return res.error(500, "Missing remote_endpoint in query!")
+  }
+
+  return getPath(source, "plugin_states")
+    .then((path) => {
+      return getCollection(path)
+        .where("remote_endpoint", "==", remote_endpoint)
+        .get()
+        .then((snapshot) => {
+          const pluginStates = snapshot.docs.reduce<Record<string,any>>((acc, doc) => {
+            try {
+              acc[doc.id] = JSON.parse(doc.data().state)
+            } catch (e) {
+              // no-op
+            }
+            return acc
+          }, {})
+          res.success({"plugin_states": pluginStates})
+        })
+    })
+    .catch((e) => {
+      console.error(e);
+      res.error(404, e.toString())
+    })
+}

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -12,6 +12,7 @@ import moveStudentWork from "./api/move-student-work"
 import getResource from "./api/get-resource"
 import fakeAnswer from "./api/fake-answer"
 import getAnswer from "./api/get-answer"
+import getPluginStates from "./api/get-plugin-states"
 
 import {
   createSyncDocAfterAnswerWritten,
@@ -38,7 +39,8 @@ api.get("/", (req, res) => {
       "POST import_structure": "Imports the structure, requires a bearer token",
       "POST move_student_work": "Moves a students work from one class to another, requires a bearer token.",
       "GET resource?source=<SOURCE>&url=<URL>": "Returns a resource under source with given url",
-      "GET answer?source=<SOURCE>&remote_endpoint=<REMOTE_ENDPOINT>&question_id=<QUESTION_ID>": "Returns the full answer document for a question by a learner"
+      "GET answer?source=<SOURCE>&remote_endpoint=<REMOTE_ENDPOINT>&question_id=<QUESTION_ID>": "Returns the full answer document for a question by a learner",
+      "GET plugin_states?source=<SOURCE>&remote_endpoint=<REMOTE_ENDPOINT>": "Returns all the plugin states for a learner's resource"
     }
   })
 })
@@ -47,6 +49,7 @@ api.post("/import_structure", importStructure)
 api.post("/move_student_work", moveStudentWork)
 api.get("/resource", getResource)
 api.get("/answer", getAnswer)
+api.get("/plugin_states", getPluginStates)
 // TODO: comment out for final PR
 api.get("/fakeAnswer", fakeAnswer)
 


### PR DESCRIPTION
This returns a (possibly empty) map of document ids to parsed plugin states for a remote endpoint under a source.