### PR TITLE
feat: Added env var to disable stats server

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -25,7 +25,7 @@ Finally if you are on Linux install the inotify tools via `sudo apt-get install 
 ### Environment Settings
 
 The server needs several environment variables set in order to start.  The easiest way to do this is create an `.env` file (which is in `.gitignore` already) with
-the following keys set.  The values of the keys are secrets and can be found in the CloudFormation parameter values for the staging and production stacks.
+the following keys set.  The values of the keys are secrets and can be found in the CloudFormation parameter values for the staging stack.
 
 ```
 export SERVER_ACCESS_KEY_ID=
@@ -34,6 +34,9 @@ export REPORT_SERVICE_TOKEN=
 export REPORT_SERVICE_URL=
 export PORTAL_REPORT_URL=
 export LEARN_PORTAL_STAGING_CONCORD_ORG_DB=mysql://<username>:<password>@<host>:<port>
+
+# add this to disable the stats server
+export DISABLE_STATS_SERVER=true
 ```
 
 ## Development

--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -48,6 +48,9 @@ config :report_server, :report_service,
 config :report_server, :portal_report,
   url: System.get_env("PORTAL_REPORT_URL") || "https://portal-report.concord.org/branch/master/" # production (yes, prod uses master)
 
+config :report_server, :stats_server,
+  disable: System.get_env("DISABLE_STATS_SERVER") == "true" || false
+
 if config_env() == :prod do
   # The secret key base is used to sign/encrypt cookies and other secrets.
   # A default value is used in config/dev.exs and config/test.exs but you

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -19,9 +19,10 @@ services:
       - REPORT_SERVICE_URL=${REPORT_SERVICE_URL:-}
       - REPORT_SERVICE_TOKEN=${REPORT_SERVICE_TOKEN:-}
       - PORTAL_URL=${PORTAL_URL:-https://learn.portal.staging.concord.org}
-      - PORTAL_REPORT_URL=${PORTAL_REPORT_URL:https://portal-report.concord.org/branch/master/}
+      - PORTAL_REPORT_URL=${PORTAL_REPORT_URL:-https://portal-report.concord.org/branch/master/}
       - TOKEN_SERVICE_URL=${TOKEN_SERVICE_URL:-https://token-service-staging.firebaseapp.com/api/v1/resources}
       - TOKEN_SERVICE_PRIVATE_BUCKET=${TOKEN_SERVICE_PRIVATE_BUCKET:-token-service-files-private}
       - OUTPUT_BUCKET=${OUTPUT_BUCKET:-report-server-output}
       - JOBS_FOLDER=${JOBS_FOLDER:-jobs}
       - TRANSCRIPTS_FOLDER=${TRANSCRIPTS_FOLDER:-transcripts}
+      - DISABLE_STATS_SERVER=${DISABLE_STATS_SERVER:-false}

--- a/server/lib/report_server_web/live/page_live/home.ex
+++ b/server/lib/report_server_web/live/page_live/home.ex
@@ -10,6 +10,7 @@ defmodule ReportServerWeb.PageLive.Home do
       |> assign(:page_title, "Home")
       |> assign(Auth.public_session_vars(session))
       |> assign(:stats, StatsServer.get_dashboard_stats())
+      |> assign(:stats_disabled, StatsServer.disabled?())
 
     # listen for the stats server message that the dashboard stats updated
     if connected?(socket) do

--- a/server/lib/report_server_web/live/page_live/home.html.heex
+++ b/server/lib/report_server_web/live/page_live/home.html.heex
@@ -1,6 +1,6 @@
 <.flash_group flash={@flash} />
 
-<div class="flex flex-col gap-4 p-4">
+<div class="flex flex-col gap-4 p-4" :if={!@stats_disabled}>
   <div class="flex gap-4" :for={{server, server_stats} <- @stats}>
     <.portal_stats server={server} stats={server_stats} />
   </div>

--- a/server/mix.exs
+++ b/server/mix.exs
@@ -4,7 +4,7 @@ defmodule ReportServer.MixProject do
   def project do
     [
       app: :report_server,
-      version: "1.2.0-pre.0",
+      version: "1.2.0-pre.1",
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
The stats server currently won't work on staging due to security group issues so this lets us disable it there.