### PR TITLE
fix: Disable ngss server for now

### DIFF
--- a/server/lib/report_server/application.ex
+++ b/server/lib/report_server/application.ex
@@ -37,7 +37,7 @@ defmodule ReportServer.Application do
 
   defp get_dashboard_servers() do
     case Application.get_env(:report_server, :portal) |> Keyword.get(:url)  do
-      "https://learn.concord.org" -> ["learn.concord.org", "ngss-assessment.portal.concord.org"]
+      "https://learn.concord.org" -> ["learn.concord.org"] # disabled for now due to networking issue: , "ngss-assessment.portal.concord.org"]
       _ -> ["learn.portal.staging.concord.org"]
     end
   end

--- a/server/lib/report_server_web/live/codap_plugin_live/index.ex
+++ b/server/lib/report_server_web/live/codap_plugin_live/index.ex
@@ -14,7 +14,7 @@ defmodule ReportServerWeb.CodapPluginLive.Index do
   alias ReportServer.PortalDbs
   alias ReportServerWeb.CodapPluginLive.Query
 
-  @servers ["learn.concord.org", "ngss-assessment.portal.concord.org"] #, "learn.portal.staging.concord.org"]
+  @servers ["learn.concord.org"] #, "ngss-assessment.portal.concord.org", "learn.portal.staging.concord.org"]
   @queries %{
     "new_student_counts_by_month" => %Query{name: "New Student Counts By Month", sql: Query.user_count_sql("portal_students", "students", :month)},
     "new_student_counts_by_year" => %Query{name: "New Student Counts By Year", sql: Query.user_count_sql("portal_students", "students", :year)},

--- a/server/mix.exs
+++ b/server/mix.exs
@@ -4,7 +4,7 @@ defmodule ReportServer.MixProject do
   def project do
     [
       app: :report_server,
-      version: "1.2.0-pre.1",
+      version: "1.2.0-pre.3",
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
The security ingress rules on production do not currently allow the report server to connect to the ngss db so it is being temporarily removed from the list of servers.

NOTE: the jump from `pre-1` to `pre-3` was because I had updated staging and production to `pre-2` and then needed to make this fix and so I needed a new docker image tag to redeploy it.