### PR TITLE
feat: Disable report tree cache in dev mode

### DIFF
--- a/server/config/dev.exs
+++ b/server/config/dev.exs
@@ -63,6 +63,9 @@ config :report_server, ReportServerWeb.Endpoint,
     ]
   ]
 
+# Disable the report tree cache in dev mode so the report.run function is not cached
+config :report_server, disable_report_tree_cache: true
+
 # Enable dev routes for dashboard and mailbox
 config :report_server, dev_routes: true
 


### PR DESCRIPTION
This prevents the run function of each report from being cached in memory which would require a restart of the server on any change to that function.