### PR TITLE
Query refinement

### DIFF
--- a/server/lib/report_server/reports/resource_metrics_details.ex
+++ b/server/lib/report_server/reports/resource_metrics_details.ex
@@ -1,34 +1,45 @@
 defmodule ReportServer.Reports.ResourceMetricsDetails do
   use ReportServer.Reports.Report
 
+  # TODO Grade level -- does not return any results
+
   def run(_filters) do
     dev_query_portal = "learn.concord.org"
     dev_query = """
     select
       trim(ea.name) as activity_name,
-      rl.teachers_name as teacher_name,
-      rl.teachers_email as teacher_email,
-      rl.school_name as school_name,
-      'TBD' as school_country,
-      rl.teachers_state as school_state,
-      rl.teachers_district as school_district,
-      count(distinct rl.class_id) as number_of_classes,
-      'TBD' as grade_levels,
+      concat(u.last_name, ', ', u.first_name) as teacher_name,
+      u.email as teacher_email,
+      ps.name as school_name,
+      pd.name as school_district,
+      ps.state as school_state,
+      pco.two_letter as school_country,
+      count(distinct pc.id) as number_of_classes,
+      pgl.name as grade_levels,
       count(distinct rl.student_id) as number_of_students,
-      'TBD' as assigned,
-      'TBD' as first_student_use,
-      'TBD' as most_recent_student_use
+      date(po.created_at) as first_assigned,
+      date(min(rl.last_run)) as first_student_use,
+      date(max(rl.last_run)) as most_recent_student_use
     from
       external_activities ea
-      join report_learners rl on (rl.runnable_id = ea.id and rl.last_run is not null)
-      join portal_schools ps on (ps.id = rl.school_id)
-      join portal_teachers pt on (pt.id = rl.teachers_id)
+      join portal_offerings po on (po.runnable_id = ea.id)
+      join portal_clazzes pc on (pc.id = po.clazz_id)
+      join portal_teacher_clazzes ptc on (ptc.clazz_id = pc.id)
+      join portal_teachers pt on (pt.id = ptc.teacher_id)
+      join users u on (u.id=pt.user_id)
+      left join portal_grade_levels_teachers pglt on (pglt.teacher_id = pt.id)
+      left join portal_grade_levels pgl on (pgl.id = pglt.grade_level_id)
+      left join portal_school_memberships psm on (psm.member_id = pt.id and psm.member_type = 'Portal::Teacher')
+      left join portal_schools ps on (ps.id = psm.school_id)
+      left join portal_districts pd on (pd.id = ps.district_id)
+      left join portal_countries pco on (pco.id = ps.country_id)
+      left join report_learners rl on (rl.runnable_id = ea.id and rl.class_id = pc.id and rl.last_run is not null)
     where
       ea.id in (2304, 3091)
     group by
-      ea.id, rl.teachers_name, rl.teachers_email, rl.school_id
+      ea.id, pt.id, u.id
     order by
-      ea.name, rl.teachers_name
+      ea.name, u.last_name, u.first_name
     """
     PortalDbs.query(dev_query_portal, dev_query)
   end

--- a/server/lib/report_server/reports/resource_metrics_summary.ex
+++ b/server/lib/report_server/reports/resource_metrics_summary.ex
@@ -6,12 +6,18 @@ defmodule ReportServer.Reports.ResourceMetricsSummary do
     dev_query = """
     select
       trim(ea.name) as activity_name,
-      count(distinct rl.teachers_id) as number_of_teachers,
-      count(distinct rl.school_id) as number_of_schools,
-      count(distinct rl.class_id) as number_of_classes,
+      count(distinct pt.id) as number_of_teachers,
+      count(distinct ps.id) as number_of_schools,
+      count(distinct pc.id) as number_of_classes,
       count(distinct rl.id) as number_of_students
     from
       external_activities ea
+      join portal_offerings po on (po.runnable_id = ea.id)
+      join portal_clazzes pc on (pc.id = po.clazz_id)
+      join portal_teacher_clazzes ptc on (ptc.clazz_id = pc.id)
+      join portal_teachers pt on (pt.id = ptc.teacher_id)
+      left join portal_school_memberships psm on (psm.member_id = pt.id and psm.member_type = 'Portal::Teacher')
+      left join portal_schools ps on (ps.id = psm.school_id)
       left join report_learners rl on (rl.runnable_id = ea.id and rl.last_run is not null)
     where
       ea.id in (2304, 3091)

--- a/server/lib/report_server/reports/tree.ex
+++ b/server/lib/report_server/reports/tree.ex
@@ -111,13 +111,13 @@ defmodule ReportServer.Reports.Tree do
         }),
         ResourceMetricsSummary.new(%Report{
           slug: "resource-metrics-summary",
-          title: "Resource Metrics Summary",
-          subtitle: "Summary report on resource metrics"
+          title: "Summary Metrics by Resource",
+          subtitle: "Includes total number of schools, number of teachers, number of classes, and number of learners per resource."
         }),
         ResourceMetricsDetails.new(%Report{
           slug: "resource-metrics-details",
-          title: "Resource Metrics Details",
-          subtitle: "Detail report on resource metrics"}
+          title: "Detailed Metrics by Resource",
+          subtitle: "Includes teacher information, school information, number of classes, number of students, and assignment information per resource."}
         )
       ]},
     ]}


### PR DESCRIPTION
Updates the three report queries.

Minor changes to the teacher report, but large rewrites to the resource summary and detail.

Properly uses the tables to look at offerings, rather than leaning on the report_learners table for everything.

One remining issue is determining grade level.  Not sure if the query is wrong or if the canned samples simply do not have grade levels specified.

Updates names and descriptions of the reports to what is in the design doc.