### PR TITLE
Header tweaks

### DIFF
--- a/server/lib/report_server_web/components/layouts/app.html.heex
+++ b/server/lib/report_server_web/components/layouts/app.html.heex
@@ -10,12 +10,15 @@
       </a>
     </div>
     <div :if={@user} class="flex flex-col font-semibold text-zinc-900">
-      <div><%= @user.portal_login %></div>
-      <div class="text-xs"><%= @user.portal_server %></div>
-      <.link navigate={~p"/auth/logout"}>Logout</.link>
+      <div><%= @user.portal_first_name %> <%= @user.portal_last_name %></div>
+      <div class="text-xs">
+        <%= @user.portal_server %>
+        <span :if={@user.portal_is_admin}>(admin)</span>
+      </div>
+      <.link class="underline" navigate={~p"/auth/logout"}>Logout</.link>
     </div>
     <div :if={!@user} class="flex items-center gap-4 font-semibold leading-4 text-zinc-900">
-      <.link navigate={~p"/auth/login"} :if={!@logged_in}>Login to <%= @portal_domain %></.link>
+      <.link class="underline" navigate={~p"/auth/login"} :if={!@logged_in}>Login to <%= @portal_domain %></.link>
     </div>
   </div>
 </header>


### PR DESCRIPTION
Display real name rather than username (which is arbitrary for google logins).
Show if user is admin.
Underline links.