### PR TITLE
Show descriptions next to report links

### DIFF
--- a/server/lib/report_server/reports/tree.ex
+++ b/server/lib/report_server/reports/tree.ex
@@ -107,7 +107,7 @@ defmodule ReportServer.Reports.Tree do
         TeacherStatus.new(%Report{
           slug: "teacher-status",
           title: "Teacher Status",
-          subtitle: "Teacher status report"
+          subtitle: "Shows what activities teachers have assigned to their classes and how many students have started them."
         }),
         ResourceMetricsSummary.new(%Report{
           slug: "resource-metrics-summary",

--- a/server/lib/report_server_web/components/custom_components.ex
+++ b/server/lib/report_server_web/components/custom_components.ex
@@ -68,6 +68,25 @@ defmodule ReportServerWeb.CustomComponents do
     """
   end
 
+  @doc """
+  Renders a square link with a description next to it.
+  attr :navigate, :any, required: true
+  attr :description, :string, required: true
+  attr :inner_block, :any, required: true
+  """
+  def described_link(assigns) do
+    ~H"""
+    <div class="flex items-center">
+      <.square_link navigate={@navigate} class="m-2 flex-shrink-0">
+        <%= render_slot(@inner_block) %>
+      </.square_link>
+      <div class="text-xl m-2">
+        <%= @description %>
+      </div>
+    </div>
+    """
+  end
+
   def download_button(assigns) do
     ~H"""
       <button id={"report-download-button-#{@filetype}"} class="my-2 p-2 bg-rose-50 rounded text-sm"

--- a/server/lib/report_server_web/live/new_report_live/index.html.heex
+++ b/server/lib/report_server_web/live/new_report_live/index.html.heex
@@ -4,10 +4,10 @@
     <:subtitle><%= @report_group.subtitle %></:subtitle>
   </.header>
 
-  <div class="mt-8 flex gap-4 flex-wrap" >
-    <.square_link navigate={report.path} :for={report <- @report_group.children}>
+  <div>
+    <.described_link navigate={report.path} description={report.subtitle} :for={report <- @report_group.children}>
       <%= report.title %>
-    </.square_link>
+    </.described_link>
   </div>
 
 <% else %>


### PR DESCRIPTION
Make reports more self-documenting by displaying the description (aka subtitle) next to each.