### PR TITLE
Limit how many rows of report on shown in live view.

### DIFF
--- a/server/lib/report_server/reports/report_query.ex
+++ b/server/lib/report_server/reports/report_query.ex
@@ -1,16 +1,21 @@
 defmodule ReportServer.Reports.ReportQuery do
   alias ReportServer.Reports.ReportQuery
 
-  defstruct select: "", from: "", join: [], where: [], group_by: "", order_by: ""
+  defstruct cols: [], from: "", join: [], where: [], group_by: "", order_by: ""
 
-  def get_sql(%ReportQuery{select: select, from: from, join: join, where: where, group_by: group_by, order_by: order_by}) do
+  def get_sql(%ReportQuery{cols: cols, from: from, join: join, where: where, group_by: group_by, order_by: order_by}) do
+    select_sql = cols |> Enum.map(fn {col, alias} -> "#{col} AS #{alias}" end) |> Enum.join(", ")
     # NOTE: the reverse is before flatten to keep any sublists in order
     join_sql = join |> Enum.reverse() |> List.flatten() |> Enum.join(" ")
     where_sql = where |> Enum.reverse() |> List.flatten() |> Enum.map(&("(#{&1})")) |> Enum.join(" AND ")
-    group_by_sql = if String.length(group_by) == 0, do: "", else: "GROUP BY #{group_by}"
-    order_by_sql = if String.length(order_by) == 0, do: "", else: "ORDER BY #{order_by}"
+    group_by_sql = if String.length(group_by) != 0, do: "GROUP BY #{group_by}", else: ""
+    order_by_sql = if !Enum.empty?(order_by) do
+       "ORDER BY " <> (order_by |> Enum.map(fn {col, dir} -> "#{col} #{Atom.to_string(dir)}" end) |> Enum.join(", "))
+    else
+      ""
+    end
 
-    "SELECT #{select} FROM #{from} #{join_sql} WHERE #{where_sql} #{group_by_sql} #{order_by_sql}"
+    "SELECT #{select_sql} FROM #{from} #{join_sql} WHERE #{where_sql} #{group_by_sql} #{order_by_sql}"
   end
 
   def update_query(report_query = %ReportQuery{}, opts) do
@@ -24,4 +29,18 @@ defmodule ReportServer.Reports.ReportQuery do
       {:ok, %{report_query | join: [ join | report_query.join ], where: [ where | report_query.where ]}}
     end
   end
+
+  # Order_by is a list of tuples, where the first element is the column name and the second is the direction.
+  # This removes any duplicate columns from the list, maintaining the order of the first occurrence.
+  def uniq_order_by(order_by) do
+    order_by |> Enum.uniq_by(fn {col, _dir} -> col end)
+  end
+
+  # Prepend the given column indexes to the list of order_by columns.
+  # Previous sorts are maintained in order, but duplicates are removed.
+  def add_sort_columns(report_query = %ReportQuery{order_by: order_by}, cols) do
+    new_order_by = cols ++ order_by |> uniq_order_by()
+    %{report_query | order_by: new_order_by}
+  end
+
 end

--- a/server/lib/report_server/reports/resource_metrics_summary.ex
+++ b/server/lib/report_server/reports/resource_metrics_summary.ex
@@ -3,13 +3,13 @@ defmodule ReportServer.Reports.ResourceMetricsSummary do
 
   def get_query(report_filter = %ReportFilter{}) do
     %ReportQuery{
-      select: """
-        trim(ea.name) as activity_name,
-        count(distinct pt.id) as number_of_teachers,
-        count(distinct ps.id) as number_of_schools,
-        count(distinct pc.id) as number_of_classes,
-        count(distinct rl.id) as number_of_students
-      """,
+      cols: [
+        {"trim(ea.name)", "activity_name"},
+        {"count(distinct pt.id)", "number_of_teachers"},
+        {"count(distinct ps.id)", "number_of_schools"},
+        {"count(distinct pc.id)", "number_of_classes"},
+        {"count(distinct rl.id)", "number_of_students"}
+      ],
       from: "external_activities ea",
       join: [[
         "join portal_offerings po on (po.runnable_id = ea.id)",
@@ -21,7 +21,7 @@ defmodule ReportServer.Reports.ResourceMetricsSummary do
         "left join report_learners rl on (rl.class_id = pc.id and rl.runnable_id = ea.id and rl.last_run is not null)"
       ]],
       group_by: "ea.id",
-      order_by: "ea.name"
+      order_by: [{"activity_name", :asc}]
     }
     |> apply_filters(report_filter)
     |> tap(&IO.inspect/1)

--- a/server/lib/report_server/reports/teacher_status.ex
+++ b/server/lib/report_server/reports/teacher_status.ex
@@ -3,17 +3,17 @@ defmodule ReportServer.Reports.TeacherStatus do
 
   def get_query(report_filter = %ReportFilter{}) do
     %ReportQuery{
-      select: """
-        concat(u.last_name, ', ', u.first_name) as teacher_name,
-        u.email as teacher_email,
-        trim(ea.name) as activity_name,
-        pc.name as class_name,
-        date(po.created_at) as date_assigned,
-        (select count(*) from portal_student_clazzes psc where psc.clazz_id = pc.id) as num_students_in_class,
-        count(distinct rl.student_id) as num_students_started,
-        date(min(rl.last_run)) as date_of_first_use,
-        date(max(rl.last_run)) as date_of_last_use
-      """,
+      cols: [
+        {"concat(u.last_name, ', ', u.first_name)", "teacher_name"},
+        {"u.email", "teacher_email"},
+        {"trim(ea.name)", "activity_name"},
+        {"pc.name", "class_name"},
+        {"date(po.created_at)", "date_assigned"},
+        {"(select count(*) from portal_student_clazzes psc where psc.clazz_id = pc.id)", "num_students_in_class"},
+        {"count(distinct rl.student_id)", "num_students_started"},
+        {"date(min(rl.last_run))", "date_of_first_use"},
+        {"date(max(rl.last_run))", "date_of_last_use"}
+      ],
       from: "portal_teachers pt",
       join: [[
         "join users u on (u.id = pt.user_id)",
@@ -24,7 +24,7 @@ defmodule ReportServer.Reports.TeacherStatus do
         "left join report_learners rl on (rl.class_id = pc.id and rl.runnable_id = ea.id and rl.last_run is not null)",
       ]],
       group_by: "u.id, ea.id, pc.id, po.id, ea.id",
-      order_by: "u.last_name, u.first_name, trim(ea.name)"
+      order_by: [{"teacher_name", :asc}, {"activity_name", :asc}]
     }
     |> apply_filters(report_filter)
   end

--- a/server/lib/report_server_web/components/custom_components.ex
+++ b/server/lib/report_server_web/components/custom_components.ex
@@ -98,7 +98,7 @@ defmodule ReportServerWeb.CustomComponents do
   end
 
   def sort_col_button(assigns) do
-    icon = if assigns.column == assigns.sort do
+    icon = if assigns.column == assigns.primary_sort do
       if assigns.sort_direction == :asc do
         "hero-arrow-down"
       else
@@ -119,7 +119,7 @@ defmodule ReportServerWeb.CustomComponents do
   Renders the report results
   """
   attr :results, :any, required: true
-  attr :sort, :string, default: nil
+  attr :primary_sort, :string, default: nil
   attr :sort_direction, :string, default: nil
   def report_results(assigns) do
     ~H"""
@@ -134,9 +134,9 @@ defmodule ReportServerWeb.CustomComponents do
       <table class="w-full border-collapse">
         <thead class="bg-gray-100 text-left leading-6 text-zinc-500">
           <tr>
-            <th :for={col <- @results.columns} class={["p-2 whitespace-nowrap border-b capitalize", (if col == @sort, do: "font-bold", else: "font-normal")]}>
+            <th :for={col <- @results.columns} class={["p-2 whitespace-nowrap border-b capitalize", (if col == @primary_sort, do: "font-bold", else: "font-normal")]}>
               <%= String.replace(col, "_", " ") %>
-              <.sort_col_button column={col} sort={@sort} sort_direction={@sort_direction} />
+              <.sort_col_button column={col} primary_sort={@primary_sort} sort_direction={@sort_direction} />
             </th>
           </tr>
         </thead>

--- a/server/lib/report_server_web/components/custom_components.ex
+++ b/server/lib/report_server_web/components/custom_components.ex
@@ -115,6 +115,25 @@ defmodule ReportServerWeb.CustomComponents do
     """
   end
 
+  def report_header(assigns) do
+    ~H"""
+    <div class="flex justify-between items-center">
+      <strong>
+        <.async_result :let={count} assign={@row_count}>
+          <:loading>Counting records...</:loading>
+          <:failed>There was an error in counting the records</:failed>
+          <span>Total: <%= count %> rows.</span>
+          <span :if={count > @row_limit}>Showing the first <%= @row_limit %>.</span>
+        </.async_result>
+      </strong>
+      <span>
+        <.download_button filetype="csv"/>
+        <.download_button filetype="json"/>
+      </span>
+    </div>
+    """
+  end
+
   @doc """
   Renders the report results
   """
@@ -123,13 +142,6 @@ defmodule ReportServerWeb.CustomComponents do
   attr :sort_direction, :string, default: nil
   def report_results(assigns) do
     ~H"""
-    <div class="flex justify-between items-center">
-      <strong>Query result: <%= @results.num_rows %> rows</strong>
-      <span>
-        <.download_button filetype="csv"/>
-        <.download_button filetype="json"/>
-      </span>
-    </div>
     <div class="bg-white text-sm overflow-auto sm:overflow-auto">
       <table class="w-full border-collapse">
         <thead class="bg-gray-100 text-left leading-6 text-zinc-500">

--- a/server/lib/report_server_web/live/report_run_live/show.ex
+++ b/server/lib/report_server_web/live/report_run_live/show.ex
@@ -136,7 +136,7 @@ defmodule ReportServerWeb.ReportRunLive.Show do
       |> PortalDbs.map_columns_on_rows()
       |> Jason.encode()
   end
-  defp format_results(result, filetype) do
+  defp format_results(_result, filetype) do
     {:error, "Unknown file type or malformed data: #{filetype}"}
   end
 

--- a/server/lib/report_server_web/live/report_run_live/show.ex
+++ b/server/lib/report_server_web/live/report_run_live/show.ex
@@ -8,7 +8,7 @@ defmodule ReportServerWeb.ReportRunLive.Show do
   alias ReportServer.Reports
   alias ReportServer.Reports.{Report, ReportQuery, ReportRun, Tree}
 
-  @row_limit 10
+  @row_limit 100
 
   @impl true
   def mount(_params, _session, socket) do
@@ -119,7 +119,7 @@ defmodule ReportServerWeb.ReportRunLive.Show do
 
   defp request_download(socket, data, filename) do
     socket
-    |> push_event("download_report", %{data: data, filename: filename}) # TODO: more informative filename
+    |> push_event("download_report", %{data: data, filename: filename})
   end
 
   defp format_results(%MyXQL.Result{} = result, "csv") do

--- a/server/lib/report_server_web/live/report_run_live/show.html.heex
+++ b/server/lib/report_server_web/live/report_run_live/show.html.heex
@@ -7,8 +7,10 @@
   <.report_filter_values report_run={@report_run} />
 </div>
 
+<.report_header row_count={@row_count} row_limit={@row_limit} />
+
 <.async_result :let={report_results} assign={@report_results}>
   <:loading>Running report...</:loading>
-  <:failed :let={error}>There was an error in running the query</:failed>
+  <:failed>There was an error in running the query</:failed>
   <.report_results results={report_results} primary_sort={@primary_sort} sort_direction={@sort_direction} />
 </.async_result>

--- a/server/lib/report_server_web/live/report_run_live/show.html.heex
+++ b/server/lib/report_server_web/live/report_run_live/show.html.heex
@@ -10,5 +10,5 @@
 <.async_result :let={report_results} assign={@report_results}>
   <:loading>Running report...</:loading>
   <:failed :let={error}>There was an error in running the query</:failed>
-  <.report_results results={report_results} sort={@sort} sort_direction={@sort_direction} />
+  <.report_results results={report_results} primary_sort={@primary_sort} sort_direction={@sort_direction} />
 </.async_result>


### PR DESCRIPTION
PT-188589069: only show the first 100 rows of queries.

No longer stores the full results of queries in memory after they are displayed.
This means query has to be re-run for sort changes and downloads.

We want the database server to do the query with a `limit`, which means it has to do the sorting as well so that we get the correct top rows.  So this includes a refactor to construct the appropriate `order by` clauses for any choice of sorting.

A separate query is contructed and executed (once, since sorts/downloads shouldn't affect it) to determine the total number of rows.

Also refactored the `ReportQuery` struct to have a list of cols rather than a single `select` string. This turned out not to be necessary but seems like it might be useful in the future so I kept it in.

Testing note: you can set `@row_limit 10` in `show.ex` to have the limit take effect more often.