### PR TITLE
doc: Add user policy docs

### DIFF
--- a/server/docs/prod-user-policy.json
+++ b/server/docs/prod-user-policy.json
@@ -1,0 +1,81 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject",
+                "transcribe:GetTranscriptionJob",
+                "s3:ListBucket"
+            ],
+            "Resource": [
+                "arn:aws:s3:::concord-report-data/workgroup-output/*",
+                "arn:aws:s3:::cc-student-work/interactive-attachments/*",
+                "arn:aws:transcribe:us-east-1:612297603577:transcription-job/*"
+            ]
+        },
+        {
+            "Sid": "VisualEditor1",
+            "Effect": "Allow",
+            "Action": [
+                "s3:PutObject",
+                "s3:GetObject",
+                "s3:ListBucket"
+            ],
+            "Resource": "arn:aws:s3:::report-server-output-prod/*"
+        },
+        {
+            "Sid": "VisualEditor2",
+            "Effect": "Allow",
+            "Action": "transcribe:StartTranscriptionJob",
+            "Resource": "*"
+        },
+        {
+            "Sid": "PortedQueryCreatorWorkgroupPolicy",
+            "Effect": "Allow",
+            "Action": [
+                "athena:GetWorkGroup",
+                "athena:CreateWorkGroup",
+                "athena:StartQueryExecution",
+                "athena:GetQueryExecution",
+                "athena:TagResource"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "PortedQueryCreatorS3OutputPolicy",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetBucketLocation",
+                "s3:GetObject",
+                "s3:ListBucket",
+                "s3:PutObject",
+                "s3:PutObjectAcl"
+            ],
+            "Resource": [
+                "arn:aws:s3:::concord-report-data",
+                "arn:aws:s3:::concord-report-data/*"
+            ]
+        },
+        {
+            "Sid": "PortedQueryCreatorS3LogInputPolicy",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetBucketLocation",
+                "s3:GetObject",
+                "s3:ListBucket"
+            ],
+            "Resource": [
+                "arn:aws:s3:::log-ingester-production",
+                "arn:aws:s3:::log-ingester-production/*"
+            ]
+        },
+        {
+            "Sid": "PortedQueryCreatorGluePolicy",
+            "Effect": "Allow",
+            "Action": "glue:GetTable",
+            "Resource": "*"
+        }
+    ]
+}

--- a/server/docs/staging-user-policy.json
+++ b/server/docs/staging-user-policy.json
@@ -1,0 +1,81 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject",
+                "transcribe:GetTranscriptionJob",
+                "s3:ListBucket"
+            ],
+            "Resource": [
+                "arn:aws:s3:::concord-staging-report-data/workgroup-output/*",
+                "arn:aws:s3:::token-service-files-private/interactive-attachments/*",
+                "arn:aws:transcribe:us-east-1:816253370536:transcription-job/*"
+            ]
+        },
+        {
+            "Sid": "VisualEditor1",
+            "Effect": "Allow",
+            "Action": [
+                "s3:PutObject",
+                "s3:GetObject",
+                "s3:ListBucket"
+            ],
+            "Resource": "arn:aws:s3:::report-server-output/*"
+        },
+        {
+            "Sid": "VisualEditor2",
+            "Effect": "Allow",
+            "Action": "transcribe:StartTranscriptionJob",
+            "Resource": "*"
+        },
+        {
+            "Sid": "PortedQueryCreatorWorkgroupPolicy",
+            "Effect": "Allow",
+            "Action": [
+                "athena:GetWorkGroup",
+                "athena:CreateWorkGroup",
+                "athena:StartQueryExecution",
+                "athena:GetQueryExecution",
+                "athena:TagResource"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "PortedQueryCreatorS3OutputPolicy",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetBucketLocation",
+                "s3:GetObject",
+                "s3:ListBucket",
+                "s3:PutObject",
+                "s3:PutObjectAcl"
+            ],
+            "Resource": [
+                "arn:aws:s3:::concord-staging-report-data",
+                "arn:aws:s3:::concord-staging-report-data/*"
+            ]
+        },
+        {
+            "Sid": "PortedQueryCreatorS3LogInputPolicy",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetBucketLocation",
+                "s3:GetObject",
+                "s3:ListBucket"
+            ],
+            "Resource": [
+                "arn:aws:s3:::log-ingester-qa",
+                "arn:aws:s3:::log-ingester-qa/*"
+            ]
+        },
+        {
+            "Sid": "PortedQueryCreatorGluePolicy",
+            "Effect": "Allow",
+            "Action": "glue:GetTable",
+            "Resource": "*"
+        }
+    ]
+}

--- a/server/docs/user-policies.md
+++ b/server/docs/user-policies.md
@@ -1,0 +1,5 @@
+# User Policies
+
+There are two JSON docs in this directory that contain the IAM user policy needed to run the server on AWS.  These policies are not part of any CloudFormation template so they will need to be recreated in the future if either the production user (on the main AWS account) or the staging user (on the QA account) are ever accidentally deleted.
+
+The ported statements to allow AWS Athena/Glue access in the policy docs were ported from the SAM template in the old create-query SAM app.


### PR DESCRIPTION
Adds the user policy docs so they are captured somewhere as they are not present in any CloudFormation template.