### PR TITLE
dev: Add server logs to the browser console

### DIFF
--- a/server/assets/js/app.ts
+++ b/server/assets/js/app.ts
@@ -116,6 +116,13 @@ let liveSocket = new LiveSocket("/live", Socket, {
 topbar.config({barColors: {0: "#29d"}, shadowColor: "rgba(0, 0, 0, .3)"})
 window.addEventListener("phx:page-loading-start", _info => topbar.show(300))
 window.addEventListener("phx:page-loading-stop", _info => topbar.hide())
+window.addEventListener("phx:live_reload:attached", (e) => {
+  const {detail: reloader} = e as any;
+  // Enable server log streaming to client.
+  // Disable with reloader.disableServerLogs()
+  reloader.enableServerLogs();
+  (window as any).liveReloader = reloader
+})
 
 // connect if there are any LiveViews on the page
 liveSocket.connect();

--- a/server/config/dev.exs
+++ b/server/config/dev.exs
@@ -56,6 +56,7 @@ config :report_server, ReportServerWeb.Endpoint,
 # Watch static and templates for browser reloading.
 config :report_server, ReportServerWeb.Endpoint,
   live_reload: [
+    web_console_logger: true,
     patterns: [
       ~r"priv/static/(?!uploads/).*(js|css|png|jpeg|jpg|gif|svg)$",
       ~r"priv/gettext/.*(po)$",

--- a/server/mix.exs
+++ b/server/mix.exs
@@ -37,7 +37,7 @@ defmodule ReportServer.MixProject do
       {:ecto_sql, "~> 3.10"},
       {:myxql, "~> 0.7.1"},
       {:phoenix_html, "~> 4.0"},
-      {:phoenix_live_reload, "~> 1.2", only: :dev},
+      {:phoenix_live_reload, "~> 1.5", only: :dev},
       {:phoenix_live_view, "~> 0.20.2"},
       {:floki, ">= 0.30.0", only: :test},
       {:phoenix_live_dashboard, "~> 0.8.3"},


### PR DESCRIPTION
This uses a new feature in phoenix_live_reload to inject the server logs into the client console for easier debugging.  This only is enabled in dev.