### PR TITLE
feat: Add report preview note to Athena reports [PT-188700907]

### DIFF
--- a/server/lib/report_server_web/components/custom_components.ex
+++ b/server/lib/report_server_web/components/custom_components.ex
@@ -126,10 +126,13 @@ defmodule ReportServerWeb.CustomComponents do
     if assigns.report.type == :athena do
       if assigns.report_run.athena_query_state == "succeeded" do
         ~H"""
-        <div class="flex justify-end items-center">
-          <span>
+        <div class="flex justify-between items-center">
+          <div>
+          <strong>Note:</strong> Report preview and JSON download are not supported for this report type.
+          </div>
+          <div>
             <.download_button filetype="csv"/>
-          </span>
+          </div>
         </div>
         """
       else


### PR DESCRIPTION
This adds the following note to the Athena reports once they succeed:

"Note: Report preview and JSON download are not supported for this report type."

![image](https://github.com/user-attachments/assets/24e417bd-64d8-45d3-8b9d-7478ae53c7e7)
