### PR TITLE
Fix number of runs in reports

### DIFF
--- a/server/lib/report_server/reports/portal/resource_metrics_details_report.ex
+++ b/server/lib/report_server/reports/portal/resource_metrics_details_report.ex
@@ -15,7 +15,7 @@ defmodule ReportServer.Reports.Portal.ResourceMetricsDetailsReport do
         {"group_concat(distinct pg.name order by cast(pg.name as unsigned))", "class_grade_levels"},
         {"count(distinct pl.student_id)", "number_of_students"},
         {"date(po.created_at)", "first_assigned"},
-        {"count(run.id)", "number_of_runs"},
+        {"count(distinct run.id)", "number_of_runs"},
         {"date(min(run.start_time))", "first_run"},
         {"date(max(run.start_time))", "last_run"},
       ],
@@ -33,7 +33,7 @@ defmodule ReportServer.Reports.Portal.ResourceMetricsDetailsReport do
         "left join portal_districts pd on (pd.id = ps.district_id)",
         "left join portal_countries pco on (pco.id = ps.country_id)",
         "left join portal_student_clazzes psc on (psc.clazz_id = pc.id)",
-        # The "exists" clause is so that portal_learners without runs don't count towards "# students started"
+        # The "exists" clause is so that portal_learners without runs don't count towards "number_of_students"
         "left join portal_learners pl on (pl.offering_id = po.id and pl.student_id = psc.student_id
             and exists (select 1 from portal_runs r2 where r2.learner_id = pl.id))",
         "left join portal_runs run on (run.learner_id = pl.id)",

--- a/server/lib/report_server/reports/portal/teacher_status_report.ex
+++ b/server/lib/report_server/reports/portal/teacher_status_report.ex
@@ -11,7 +11,7 @@ defmodule ReportServer.Reports.Portal.TeacherStatusReport do
         {"date(po.created_at)", "date_assigned"},
         {"(select count(*) from portal_student_clazzes psc where psc.clazz_id = pc.id)", "num_students_in_class"},
         {"count(distinct pl.student_id)", "num_students_started"},
-        {"count(run.id)", "number_of_runs"},
+        {"count(distinct run.id)", "number_of_runs"},
         {"date(min(run.start_time))", "first_run"},
         {"date(max(run.start_time))", "last_run"}
       ],


### PR DESCRIPTION
Addresses QA comment in PT-188613525

Count of number of runs in details report was wrong due to lack of `distinct` in query.
Teacher status report appeared to be correct but adding `distinct` on runs there as well in case untested cases or future updates cause retrieval of multiple rows with the same run id.
