### PR TITLE
fix: Added check for no learners [PT-188527607]

### DIFF
--- a/server/lib/report_server/reports/athena/learner_data.ex
+++ b/server/lib/report_server/reports/athena/learner_data.ex
@@ -139,7 +139,8 @@ defmodule ReportServer.Reports.Athena.LearnerData do
     teacher_ids = get_unique_ids(rows, :teachers_id)
     permission_form_ids = get_unique_ids(rows, :permission_forms_id)
 
-    with {:ok, teacher_map} <- get_teacher_map(teacher_ids, user),
+    with {:ok, rows} <- ensure_not_empty(rows, "No learner data found"),
+         {:ok, teacher_map} <- get_teacher_map(teacher_ids, user),
          {:ok, permission_form_map } <- get_permission_form_map(permission_form_ids, user) do
 
       result = rows
@@ -204,7 +205,7 @@ defmodule ReportServer.Reports.Athena.LearnerData do
     end)
   end
 
-  defp get_teacher_map([], _user = %User{}), do: %{}
+  defp get_teacher_map([], _user = %User{}), do: {:ok, %{}}
   defp get_teacher_map(teacher_ids, user = %User{}) do
     portal_query = %ReportQuery{
       cols: [
@@ -241,7 +242,7 @@ defmodule ReportServer.Reports.Athena.LearnerData do
     end
   end
 
-  defp get_permission_form_map([], _user = %User{}), do: %{}
+  defp get_permission_form_map([], _user = %User{}), do: {:ok, %{}}
   defp get_permission_form_map(permission_form_ids, user = %User{}) do
     portal_query = %ReportQuery{
       cols: [

--- a/server/lib/report_server/reports/report_utils.ex
+++ b/server/lib/report_server/reports/report_utils.ex
@@ -75,4 +75,21 @@ defmodule ReportServer.Reports.ReportUtils do
   def escape_single_quote(str) do
     String.replace(str, "'", "''")
   end
+
+  def ensure_not_empty(list, error_message) when is_list(list) do
+    if Enum.empty?(list) do
+      {:error, error_message}
+    else
+      {:ok, list}
+    end
+  end
+
+  def ensure_not_empty(map, error_message) when is_map(map) do
+    if map_size(map) == 0 do
+      {:error, error_message}
+    else
+      {:ok, map}
+    end
+  end
+
 end

--- a/server/lib/report_server_web/live/report_run_live/show.ex
+++ b/server/lib/report_server_web/live/report_run_live/show.ex
@@ -131,6 +131,11 @@ defmodule ReportServerWeb.ReportRunLive.Show do
       {:error, error} ->
         Logger.error(error)
         {:error, error}
+
+      error ->
+        # note: this is a catch-all for any errors that may occur
+        Logger.error("Failed to run Athena report: #{inspect(error)}")
+        {:error, "Unknown error: failed to run Athena report"}
     end
   end
 


### PR DESCRIPTION
This fix causes the query to exit early with a "No learner data found" error when there are no learners found matching a query.