### PR TITLE
fix: Crash on large requests [PT-188748565]

### DIFF
--- a/server/lib/report_server/reports/athena/resource_data.ex
+++ b/server/lib/report_server/reports/athena/resource_data.ex
@@ -68,6 +68,8 @@ defmodule ReportServer.Reports.Athena.ResourceData do
       |> Req.get(url: url,
         auth: {:bearer, token },
         params: [source: source, url: reported_url],
+        retry: false,
+        retry_log_level: false,
         debug: false
       )
       |> parse_resource_response()

--- a/server/lib/report_server/reports/athena/shared_queries.ex
+++ b/server/lib/report_server/reports/athena/shared_queries.ex
@@ -213,10 +213,10 @@ defmodule ReportServer.Reports.Athena.SharedQueries do
             questions = Map.get(denormalized_resource, :questions, %{})
             denormalized_resource
             |> Map.get(:question_order)
-            |> Enum.map(fn question_id ->
+            |> Enum.reduce(acc, fn question_id, acc2 ->
               question = Map.get(questions, question_id)
               question_columns = get_columns_for_question(question_id, question, denormalized_resource, auth_domain, activity_index)
-              [[question_columns] | acc]
+              [[question_columns] | acc2]
             end)
           else
             acc


### PR DESCRIPTION
This fixes a bug in the code that generated the question columns in the shared query.  The inner loop of the reducer was mapping its result instead of reducing on it.  This caused enormously large nested lists to be created when there were a large number of columns.  These nested lists caused geometric slowdown of each reduce pass as the lists increased in size.

The fix for this was to reduce instead of mapping in the inner reducer - this causes the list to only increase in side proportional to the number of columns.

I also added a flag to skip retries of the resource if the Firebase function returns 500, which it does when the function does not provide a source parameter that is correct.