### PR TITLE
fix: Accidentally removes List.reverse call [PT-188527607]

### DIFF
--- a/server/lib/report_server/reports/athena/shared_queries.ex
+++ b/server/lib/report_server/reports/athena/shared_queries.ex
@@ -222,6 +222,7 @@ defmodule ReportServer.Reports.Athena.SharedQueries do
             acc
           end
         end)
+        |> Enum.reverse()
         |> List.flatten()
 
       all_columns = all_columns ++ questions_columns


### PR DESCRIPTION
This line was accidentally removed while debugging the column ordering issue.