### PR TITLE
fix: Move /reports to /old-reports [PT-188779638]

### DIFF
--- a/server/lib/report_server_web/aws.ex
+++ b/server/lib/report_server_web/aws.ex
@@ -37,7 +37,7 @@ defmodule ReportServerWeb.Aws do
       "Query" => "-- name Demo Query ##{query_id}\n  -- type activity\n  -- reportType details\n",
       "QueryExecutionId" => query_id,
       "ResultConfiguration" => %{
-        "OutputLocation" => "/reports/demo.csv"
+        "OutputLocation" => "/old-reports/demo.csv"
       },
       "Status" => %{
         "State" => state,
@@ -58,7 +58,7 @@ defmodule ReportServerWeb.Aws do
   end
 
   def get_presigned_url("demo", _workgroup_credentials, _s3_url, _filename) do
-    {:ok, "/reports/demo.csv"}
+    {:ok, "/old-reports/demo.csv"}
   end
 
   def get_presigned_url(_mode, workgroup_credentials, s3_url, filename) do

--- a/server/lib/report_server_web/live/page_live/home.html.heex
+++ b/server/lib/report_server_web/live/page_live/home.html.heex
@@ -6,14 +6,24 @@
   </div>
 </div>
 
-<div class="p-4">
-  <div class="flex w-full">
+<div class="p-4 flex gap-4">
+  <div class="flex">
     <.square_link
-      navigate={~p"/reports"}
+      navigate={~p"/old-reports"}
       class="gap-4 bg-orange hover:bg-light-orange hover:text-orange hover:border hover:border-orange"
     >
       <.icon name="hero-document-chart-bar" />
-      Your Reports
+      Old Reports
+    </.square_link>
+  </div>
+
+  <div class="flex">
+    <.square_link
+      navigate={~p"/new-reports"}
+      class="gap-4 bg-orange hover:bg-light-orange hover:text-orange hover:border hover:border-orange"
+    >
+      <.icon name="hero-document-chart-bar" />
+      New Reports
     </.square_link>
   </div>
 </div>

--- a/server/lib/report_server_web/live/report_live/index.ex
+++ b/server/lib/report_server_web/live/report_live/index.ex
@@ -23,7 +23,7 @@ defmodule ReportServerWeb.ReportLive.Index do
         |> assign_async(:aws_data, fn -> async_get_aws_data(mode, portal_credentials) end)
       }
     else
-      {:ok, redirect(socket, to: ~p"/auth/login?return_to=/reports")}
+      {:ok, redirect(socket, to: ~p"/auth/login?return_to=/old-reports")}
     end
   end
 

--- a/server/lib/report_server_web/live/report_live/query.ex
+++ b/server/lib/report_server_web/live/report_live/query.ex
@@ -208,12 +208,12 @@ defmodule ReportServerWeb.ReportLive.QueryComponent do
   @impl true
   def handle_event("download", params = %{"type" => type}, socket = %{assigns: %{mode: "demo", jobs: jobs}}) do
     presigned_url = case type do
-      "original" -> "/reports/demo.csv"
+      "original" -> "/old-reports/demo.csv"
 
       "job" ->
         job = Enum.find(jobs, fn %{id: id} -> "#{id}" == params["jobId"] end)
         result = Base.encode64(job.result)
-        "/reports/job.csv?filename=job-#{job.id}.csv&result=#{result}"
+        "/old-reports/job.csv?filename=job-#{job.id}.csv&result=#{result}"
 
       _ -> nil
     end

--- a/server/lib/report_server_web/router.ex
+++ b/server/lib/report_server_web/router.ex
@@ -45,7 +45,7 @@ defmodule ReportServerWeb.Router do
     end
   end
 
-  scope "/reports", ReportServerWeb do
+  scope "/old-reports", ReportServerWeb do
     pipe_through :browser
 
     live "/", ReportLive.Index, :index


### PR DESCRIPTION
This is the first step in a three step process to remove the old reports and replace the /reports url with the new reports.

Once this is live the existing query-creator Firebase function can be updated to redirect to /old-reports.  Once that is live then a follow on PR will rename /new-reports to /reports.

Then, the portals can then be updated to remove the report links from the admin and add the report link in the sidebar to point to /reports.

Finally, a follow on PR will remove all the /old-reports code that is no longer needed.