### PR TITLE
feat: Move /new-reports to /reports [PT-188779638]

### DIFF
--- a/server/lib/report_server_web/components/custom_components.ex
+++ b/server/lib/report_server_web/components/custom_components.ex
@@ -300,7 +300,7 @@ defmodule ReportServerWeb.CustomComponents do
         </thead>
         <tbody>
           <tr :for={report_run <- @report_runs} class="group hover:bg-zinc-200 even:bg-gray-50">
-            <td class="p-2 font-normal border-b align-top"><.link class="underline" href={"/new-reports/runs/#{report_run.id}"}><%= report_run.id %></.link></td>
+            <td class="p-2 font-normal border-b align-top"><.link class="underline" href={"/reports/runs/#{report_run.id}"}><%= report_run.id %></.link></td>
             <td class="p-2 font-normal border-b align-top" :if={@include_user}><%= report_run.user.portal_first_name %> <%= report_run.user.portal_last_name %></td>
             <td class="p-2 font-normal border-b align-top" :if={@include_report_titles}><%= @report_titles[report_run.report_slug] %></td>
             <td class="p-2 font-normal border-b align-top"><.report_filter_values report_run={report_run} /></td>

--- a/server/lib/report_server_web/live/new_report_live/form.ex
+++ b/server/lib/report_server_web/live/new_report_live/form.ex
@@ -218,7 +218,7 @@ defmodule ReportServerWeb.NewReportLive.Form do
     socket = case Reports.create_report_run(report_run_attrs) do
       {:ok, report_run} ->
         socket
-          |> redirect(to: ~p"/new-reports/runs/#{report_run.id}")
+          |> redirect(to: ~p"/reports/runs/#{report_run.id}")
 
       {:error, changeset} ->
         Logger.error(changeset)

--- a/server/lib/report_server_web/live/new_report_live/index.html.heex
+++ b/server/lib/report_server_web/live/new_report_live/index.html.heex
@@ -4,12 +4,12 @@
     <:subtitle><%= @report_group.subtitle %></:subtitle>
   </.header>
 
-  <.described_link navigate={~p"/new-reports/runs"} description={"Lists your previous report runs"} :if={@is_root}>
+  <.described_link navigate={~p"/reports/runs"} description={"Lists your previous report runs"} :if={@is_root}>
     Your Runs
   </.described_link>
 
   <%= if @user.portal_is_admin do %>
-    <.described_link navigate={~p"/new-reports/all-runs"} description={"Lists all the report runs (because you are an admin)"} :if={@is_root}>
+    <.described_link navigate={~p"/reports/all-runs"} description={"Lists all the report runs (because you are an admin)"} :if={@is_root}>
       All Runs
     </.described_link>
   <% end %>

--- a/server/lib/report_server_web/live/page_live/home.html.heex
+++ b/server/lib/report_server_web/live/page_live/home.html.heex
@@ -7,6 +7,17 @@
 </div>
 
 <div class="p-4 flex gap-4">
+
+  <div class="flex">
+    <.square_link
+      navigate={~p"/reports"}
+      class="gap-4 bg-orange hover:bg-light-orange hover:text-orange hover:border hover:border-orange"
+    >
+      <.icon name="hero-document-chart-bar" />
+      Reports
+    </.square_link>
+  </div>
+
   <div class="flex">
     <.square_link
       navigate={~p"/old-reports"}
@@ -14,16 +25,6 @@
     >
       <.icon name="hero-document-chart-bar" />
       Old Reports
-    </.square_link>
-  </div>
-
-  <div class="flex">
-    <.square_link
-      navigate={~p"/new-reports"}
-      class="gap-4 bg-orange hover:bg-light-orange hover:text-orange hover:border hover:border-orange"
-    >
-      <.icon name="hero-document-chart-bar" />
-      New Reports
     </.square_link>
   </div>
 </div>

--- a/server/lib/report_server_web/live/report_run_live/index.ex
+++ b/server/lib/report_server_web/live/report_run_live/index.ex
@@ -31,7 +31,7 @@ defmodule ReportServerWeb.ReportRunLive.Index do
     else
       socket = socket
         |> put_flash(:error, "Sorry, you don't have access to that page.")
-        |> redirect(to: "/new-reports")
+        |> redirect(to: "/reports")
 
       {:ok, socket}
     end

--- a/server/lib/report_server_web/live/report_run_live/index.html.heex
+++ b/server/lib/report_server_web/live/report_run_live/index.html.heex
@@ -1,6 +1,6 @@
 <div :if={length(@report_runs) > 0}>
   <div class="font-bold my-2">
-    <.breadcrumbs previous={[{"Reports", ~p"/new-reports"}]} current={@page_title} />
+    <.breadcrumbs previous={[{"Reports", ~p"/reports"}]} current={@page_title} />
   </div>
 
   <.report_runs report_runs={@report_runs} include_report_titles={true} include_user={@user.portal_is_admin} />

--- a/server/lib/report_server_web/live/report_run_live/show.ex
+++ b/server/lib/report_server_web/live/report_run_live/show.ex
@@ -48,7 +48,7 @@ defmodule ReportServerWeb.ReportRunLive.Show do
     else
       socket = socket
         |> put_flash(:error, "You are not authorized to access the requested report.")
-        |> redirect(to: "/new-reports")
+        |> redirect(to: "/reports")
       {:noreply, socket}
     end
   end

--- a/server/lib/report_server_web/redirect_to_reports.ex
+++ b/server/lib/report_server_web/redirect_to_reports.ex
@@ -1,0 +1,13 @@
+defmodule ReportServerWeb.RedirectToReports do
+  @moduledoc """
+  Redirects all requests to /reports using the path from the request.
+  """
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    to = ["/reports" | conn.params["path"]] |> Enum.join("/")
+    conn
+    |> Phoenix.Controller.redirect(to: to)
+  end
+end

--- a/server/lib/report_server_web/router.ex
+++ b/server/lib/report_server_web/router.ex
@@ -53,7 +53,14 @@ defmodule ReportServerWeb.Router do
     get "/job.csv", DemoController, :job
   end
 
+  # this directs all requests to /new-reports to /reports for backwards compatibility
   scope "/new-reports", ReportServerWeb do
+    pipe_through :browser
+
+    get "/*path", RedirectToReports, []
+  end
+
+  scope "/reports", ReportServerWeb do
     pipe_through :browser
 
     live_session :reports, on_mount: ReportServerWeb.NewReportLive.Auth do


### PR DESCRIPTION
This updates all /new-reports links to /reports and adds a plug to automatically redirect /new-report urls to /reports so test links don't break.