### PR TITLE
Add primary_user_id to reports

### DIFF
--- a/server/lib/report_server/reports/athena/learner_data.ex
+++ b/server/lib/report_server/reports/athena/learner_data.ex
@@ -31,6 +31,7 @@ defmodule ReportServer.Reports.Athena.LearnerData do
         {"rl.class_name", "class"},
         {"rl.school_name", "school"},
         {"rl.user_id", "user_id"},
+        {"COALESCE(u.primary_account_id, u.id)", "primary_user_id"},
         {"rl.offering_id", "offering_id"},
         {"rl.username", "username"},
         {"rl.student_name", "student_name"},
@@ -44,6 +45,7 @@ defmodule ReportServer.Reports.Athena.LearnerData do
       from: "report_learners rl",
       join: [[
         "JOIN portal_learners pl ON (rl.learner_id = pl.id)",
+        "JOIN users u ON (u.id = rl.user_id)",
         "JOIN portal_offerings po ON (po.id = rl.offering_id)",
         "JOIN external_activities ea on (po.runnable_type = 'ExternalActivity' AND po.runnable_id = ea.id)",
         "JOIN portal_student_clazzes psc ON (psc.student_id = rl.student_id)",
@@ -178,6 +180,7 @@ defmodule ReportServer.Reports.Athena.LearnerData do
             class: row.class,
             school: row.school,
             user_id: row.user_id,
+            primary_user_id: row.primary_user_id,
             offering_id: row.offering_id,
             permission_forms: permission_forms,
             username: row.username,

--- a/server/lib/report_server/reports/athena/learner_data.ex
+++ b/server/lib/report_server/reports/athena/learner_data.ex
@@ -113,11 +113,11 @@ defmodule ReportServer.Reports.Athena.LearnerData do
       {
         [
           "JOIN portal_teachers pt ON (pt.id = ptc.teacher_id)",
-          "JOIN users u ON u.id = pt.user_id"
+          "JOIN users teacher_u ON u.id = pt.user_id"
           | join,
         ],
         [
-          "u.email NOT LIKE '%@concord.org'"
+          "teacher_u.email NOT LIKE '%@concord.org'"
           | where
         ]
       }

--- a/server/lib/report_server/reports/athena/learner_data.ex
+++ b/server/lib/report_server/reports/athena/learner_data.ex
@@ -173,6 +173,7 @@ defmodule ReportServer.Reports.Athena.LearnerData do
           run_remote_endpoint = "https://#{user.portal_server}/dataservice/external_activity_data/#{row.secure_key}"
 
           # use same format as api
+          # These names must also be specified in the AWS Glue configuration
           %{
             student_id: row.student_id,
             learner_id: row.learner_id,

--- a/server/lib/report_server/reports/athena/shared_queries.ex
+++ b/server/lib/report_server/reports/athena/shared_queries.ex
@@ -164,6 +164,7 @@ defmodule ReportServer.Reports.Athena.SharedQueries do
       unique_user_class AS
         (SELECT class_id,
           user_id,
+          arbitrary(primary_user_id) as primary_user_id,
           arbitrary(student_id) as student_id,
           arbitrary(#{if hide_names, do: "student_id", else: "student_name"}) as student_name,
           arbitrary(#{maybe_hash_username(hide_names, "username", true)}) as username,
@@ -185,6 +186,7 @@ defmodule ReportServer.Reports.Athena.SharedQueries do
     default_columns = [
       "student_id",
       "user_id",
+      "primary_user_id",
       "student_name",
       "username",
       "school",
@@ -276,6 +278,7 @@ defmodule ReportServer.Reports.Athena.SharedQueries do
       SELECT
         unique_user_class.student_id,
         unique_user_class.user_id,
+        unique_user_class.primary_user_id,
         unique_user_class.student_name,
         unique_user_class.username,
         unique_user_class.school,
@@ -309,6 +312,7 @@ defmodule ReportServer.Reports.Athena.SharedQueries do
     metadata_column_names = [
       "student_id",
       "user_id",
+      "primary_user_id",
       "student_name",
       "username",
       "school",

--- a/server/lib/report_server/reports/athena/student_actions_report.ex
+++ b/server/lib/report_server/reports/athena/student_actions_report.ex
@@ -1,109 +1,17 @@
 defmodule ReportServer.Reports.Athena.StudentActionsReport do
   use ReportServer.Reports.Report, type: :athena
 
-  alias ReportServer.PortalDbs
+  alias ReportServer.Reports.Athena.LearnerData
 
   def get_query(report_filter = %ReportFilter{}, user = %User{}) do
-    case get_run_remote_endpoints(report_filter, user) do
-      {:ok, run_remote_endpoints} ->
-        hide_names = report_filter.hide_names
-        remove_username = false
-
-        if !Enum.empty?(run_remote_endpoints) do
-          {:ok, %ReportQuery{
-            cols: ReportQuery.get_log_cols(hide_names: hide_names, remove_username: remove_username),
-            from: "\"#{ReportQuery.get_log_db_name()}\".\"logs_by_time\" log",
-            where: [["\"log\".\"run_remote_endpoint\" IN #{string_list_to_single_quoted_in(run_remote_endpoints)}"]]
-          }}
-        else
-          {:error, "No learners found to match the requested filter(s)."}
-        end
-
-      error -> error
-    end
-  end
-
-  defp get_run_remote_endpoints(%ReportFilter{cohort: cohort, school: school, teacher: teacher, assignment: assignment, permission_form: permission_form, start_date: start_date, end_date: end_date}, user = %User{}) do
-    portal_query = %ReportQuery{
-      cols: [{"DISTINCT pl.secure_key", "secure_key"}],
-      from: "portal_learners pl",
-      join: [[
-        "JOIN report_learners rl ON (rl.learner_id = pl.id)",
-        "JOIN portal_offerings po ON (po.id = rl.offering_id)",
-        "JOIN portal_student_clazzes psc ON (psc.student_id = rl.student_id)",
-        "JOIN portal_teacher_clazzes ptc ON (ptc.clazz_id = psc.clazz_id)",
-        "LEFT JOIN portal_runs run on (run.learner_id = pl.id)",
-      ]]
-    }
-
-    join = []
-    where = []
-
-    allowed_project_ids = PortalDbs.get_allowed_project_ids(user)
-    {join, where} = if allowed_project_ids == :all do
-      {join, where}
-    else
-      {
-        [
-          "join admin_cohort_items aci_teacher on (aci_teacher.item_type = 'Portal::Teacher' AND aci_teacher.item_id = ptc.teacher_id)",
-          "join admin_cohort_items aci_assignment on (aci_assignment.item_type = 'ExternalActivity' AND aci_assignment.item_id = po.runnable_id)",
-          "join admin_cohorts ac_teacher ON (ac_teacher.id = aci_teacher.admin_cohort_id)",
-          "join admin_cohorts ac_assignment ON (ac_assignment.id = aci_assignment.admin_cohort_id)"
-          | join
-        ],
-        [
-          "ac_teacher.project_id IN #{list_to_in(allowed_project_ids)}",
-          "ac_assignment.project_id IN #{list_to_in(allowed_project_ids)}"
-          | where
-        ]
-      }
-    end
-
-    {join, where} = if have_filter?(cohort) do
-      {
-        [
-          "join admin_cohort_items aci_teacher on (aci_teacher.item_type = 'Portal::Teacher' AND aci_teacher.item_id = ptc.teacher_id)",
-          "join admin_cohort_items aci_assignment on (aci_assignment.item_type = 'ExternalActivity' AND aci_assignment.item_id = po.runnable_id)"
-          | join
-        ],
-        [
-          "aci_teacher.admin_cohort_id in #{list_to_in(cohort)}",
-          "aci_assignment.admin_cohort_id in #{list_to_in(cohort)}"
-          | where
-        ]
-      }
-    else
-      {join, where}
-    end
-
-    {join, where} = if have_filter?(permission_form) do
-      {
-        [
-          "JOIN portal_student_permission_forms pspf ON (pspf.portal_student_id = psc.student_id)"
-          | join
-        ],
-        [
-          "pspf.portal_permission_form_id IN #{list_to_in(permission_form)}"
-          | where
-        ]
-      }
-    else
-      {join, where}
-    end
-
-    where = where
-      |> apply_where_filter(school, "rl.school_id IN #{list_to_in(school)}")
-      |> apply_where_filter(teacher, "ptc.teacher_id IN #{list_to_in(teacher)}")
-      |> apply_where_filter(assignment, "po.runnable_id IN #{list_to_in(assignment)}")
-      |> apply_start_date(start_date)
-      |> apply_end_date(end_date)
-
-    with {:ok, portal_query} <- ReportQuery.update_query(portal_query, join: join, where: where),
-         {:ok, sql} <- ReportQuery.get_sql(portal_query),
-         {:ok, result} <- PortalDbs.query(user.portal_server, sql) do
-      {:ok, Enum.map(result.rows, fn [secure_key] -> "https://#{user.portal_server}/dataservice/external_activity_data/#{secure_key}" end)}
+    hide_names = report_filter.hide_names
+    learner_cols = ReportQuery.get_minimal_learner_cols(hide_names: hide_names)
+    with {:ok, learner_data} <- LearnerData.fetch_and_upload(report_filter, user),
+    {:ok, query} <- ReportQuery.get_athena_query(report_filter, learner_data, learner_cols) do
+      {:ok, query}
     else
       error -> error
     end
   end
+
 end

--- a/server/lib/report_server/reports/athena/student_actions_with_metadata_report.ex
+++ b/server/lib/report_server/reports/athena/student_actions_with_metadata_report.ex
@@ -1,46 +1,17 @@
 defmodule ReportServer.Reports.Athena.StudentActionsWithMetadataReport do
-  require Logger
-
   use ReportServer.Reports.Report, type: :athena
 
   alias ReportServer.Reports.Athena.LearnerData
 
   def get_query(report_filter = %ReportFilter{}, user = %User{}) do
+    hide_names = report_filter.hide_names
+    learner_cols = ReportQuery.get_learner_cols(hide_names: hide_names)
     with {:ok, learner_data} <- LearnerData.fetch_and_upload(report_filter, user),
-         {:ok, query} <- get_athena_query(report_filter, learner_data) do
+         {:ok, query} <- ReportQuery.get_athena_query(report_filter, learner_data, learner_cols) do
       {:ok, query}
     else
       error -> error
     end
   end
 
-  defp get_athena_query(report_filter = %ReportFilter{}, learner_data) do
-    query_ids = learner_data |> Enum.map(&(&1.query_id))
-
-    if !Enum.empty?(query_ids) do
-      hide_names = report_filter.hide_names
-
-      log_cols = ReportQuery.get_log_cols(hide_names: hide_names, remove_username: true)
-      learner_cols = ReportQuery.get_learner_cols(hide_names: hide_names)
-      cols = List.flatten([log_cols | learner_cols])
-
-      from = "\"#{ReportQuery.get_log_db_name()}\".\"logs_by_time\" log"
-
-      join = [
-        """
-        INNER JOIN "report-service"."learners" learner
-        ON
-          (
-            learner.query_id IN #{string_list_to_single_quoted_in(query_ids)}
-            AND
-            learner.run_remote_endpoint = log.run_remote_endpoint
-          )
-        """
-      ]
-
-      {:ok, %ReportQuery{cols: cols, from: from, join: join }}
-    else
-      {:error, "No learners found to match the requested filter(s)."}
-    end
-  end
 end

--- a/server/lib/report_server/reports/report_query.ex
+++ b/server/lib/report_server/reports/report_query.ex
@@ -1,6 +1,9 @@
 defmodule ReportServer.Reports.ReportQuery do
+
   alias ReportServer.Reports.ReportQuery
   alias ReportServer.Reports.Athena.AthenaConfig
+  alias ReportServer.Reports.ReportFilter
+  alias ReportServer.Reports.ReportUtils
 
   defstruct cols: [], from: "", join: [], where: [], group_by: "", order_by: [], raw_sql: nil
 
@@ -68,12 +71,50 @@ defmodule ReportServer.Reports.ReportQuery do
   end
 
   def get_learner_cols(opts \\ []) do
-    hide_names = Keyword.get(opts, :hide_names, false)
+    format_as_learner_col_list(opts,
+      ["learner_id", "class_id", "runnable_url", "student_id", "class", "school", "user_id", "primary_user_id", "offering_id", "permission_forms", "username", "student_name", "teachers", "last_run"])
+  end
 
-    ["learner_id", "class_id", "runnable_url", "student_id", "class", "school", "user_id", "primary_user_id", "offering_id", "permission_forms", "username", "student_name", "teachers", "last_run"]
+  def get_minimal_learner_cols(opts \\ []) do
+    format_as_learner_col_list(opts,
+      ["user_id", "primary_user_id"])
+  end
+
+  defp format_as_learner_col_list(opts, column_names) do
+    hide_names = Keyword.get(opts, :hide_names, false)
+    column_names
       |> Enum.map(&(to_tuple("learner", &1)))
       |> Enum.map(&(hash_username(&1, hide_names)))
       |> Enum.map(&(hide_learner_student_name(&1, hide_names)))
+  end
+
+  def get_athena_query(report_filter = %ReportFilter{}, learner_data, learner_cols) do
+    query_ids = learner_data |> Enum.map(&(&1.query_id))
+
+    if !Enum.empty?(query_ids) do
+      hide_names = report_filter.hide_names
+
+      log_cols = ReportQuery.get_log_cols(hide_names: hide_names, remove_username: true)
+      cols = List.flatten([log_cols | learner_cols])
+
+      from = "\"#{ReportQuery.get_log_db_name()}\".\"logs_by_time\" log"
+
+      join = [
+        """
+        INNER JOIN "report-service"."learners" learner
+        ON
+          (
+            learner.query_id IN #{ReportUtils.string_list_to_single_quoted_in(query_ids)}
+            AND
+            learner.run_remote_endpoint = log.run_remote_endpoint
+          )
+        """
+      ]
+
+      {:ok, %ReportQuery{cols: cols, from: from, join: join }}
+    else
+      {:error, "No learners found to match the requested filter(s)."}
+    end
   end
 
   def get_log_db_name() do

--- a/server/lib/report_server/reports/report_query.ex
+++ b/server/lib/report_server/reports/report_query.ex
@@ -70,7 +70,7 @@ defmodule ReportServer.Reports.ReportQuery do
   def get_learner_cols(opts \\ []) do
     hide_names = Keyword.get(opts, :hide_names, false)
 
-    ["learner_id", "class_id", "runnable_url", "student_id", "class", "school", "user_id", "offering_id", "permission_forms", "username", "student_name", "teachers", "last_run"]
+    ["learner_id", "class_id", "runnable_url", "student_id", "class", "school", "user_id", "primary_user_id", "offering_id", "permission_forms", "username", "student_name", "teachers", "last_run"]
       |> Enum.map(&(to_tuple("learner", &1)))
       |> Enum.map(&(hash_username(&1, hide_names)))
       |> Enum.map(&(hide_learner_student_name(&1, hide_names)))


### PR DESCRIPTION
This adds a `primary_user_id` column to the **Student Answers**, **Student Actions**, and **Student Actions with Metadata** reports.

**Student Actions** did not previously have any columns other than what is in the log data itself. For that report this PR adds the `user_id` column as well as `primary_user_id`. In order to do this the report is refactored to work like *Student Actions with Metadata** but with just the minimal 2 columns being joined on from portal data, rather than the longer list of metadata columns.

