### PR TITLE
Fix error in count SQL

### DIFF
--- a/server/lib/report_server/reports/report_query.ex
+++ b/server/lib/report_server/reports/report_query.ex
@@ -29,7 +29,7 @@ defmodule ReportServer.Reports.ReportQuery do
   end
 
   def get_count_sql(%ReportQuery{from: from, join: join, where: where, group_by: group_by}) do
-    query_without_cols_or_order = %ReportQuery{cols: [{"1", "row"}], from: from, join: join, where: where, group_by: group_by}
+    query_without_cols_or_order = %ReportQuery{cols: [{"1", "qrow"}], from: from, join: join, where: where, group_by: group_by}
     {:ok, subquery} = get_sql(query_without_cols_or_order)
 
     {:ok, "SELECT COUNT(*) AS count FROM (#{subquery}) AS subquery"}


### PR DESCRIPTION
After MySQL upgrade on staging, count of rows at the top of portal report pages is showing an error.

Seems to be because "row" is a reserved word in MySQL, which may be more strictly enforced in v8.