### PR TITLE
Update Portal metrics reports to avoid double counting

### DIFF
--- a/server/lib/report_server/post_processing/job_server.ex
+++ b/server/lib/report_server/post_processing/job_server.ex
@@ -32,6 +32,10 @@ defmodule ReportServer.PostProcessing.JobServer do
     ClueLinkToWork.step(),
   ] |> sort_steps()
 
+  def get_steps(_mode, "student-actions-with-metadata"), do: [
+    ClueLinkToWork.step(),
+  ] |> sort_steps()
+
   def get_steps(_mode, _report_type), do: []
 
   def sort_steps(steps) do

--- a/server/lib/report_server/post_processing/steps/clue_link_to_work.ex
+++ b/server/lib/report_server/post_processing/steps/clue_link_to_work.ex
@@ -11,7 +11,7 @@ defmodule ReportServer.PostProcessing.Steps.ClueLinkToWork do
   def step do
     %Step{
       id: @id,
-      label: "Add \"link_to_work\" column to CLUE Student Actions report",
+      label: "Add \"link_to_work\" column to CLUE \"Student Actions\" or \"Student Actions with Metadata\" report",
       init: &init/1,
       process_row: &process_row/3,
       preprocess_learners: true

--- a/server/lib/report_server/reports/portal/resource_metrics_details_report.ex
+++ b/server/lib/report_server/reports/portal/resource_metrics_details_report.ex
@@ -13,7 +13,7 @@ defmodule ReportServer.Reports.Portal.ResourceMetricsDetailsReport do
         {"pco.two_letter", "school_country"},
         {"count(distinct pc.id)", "number_of_classes"},
         {"group_concat(distinct pg.name order by cast(pg.name as unsigned))", "class_grade_levels"},
-        {"count(distinct pl.student_id)", "number_of_students"},
+        {"count(distinct coalesce(stu.primary_account_id, stu.id))", "number_of_students"},
         {"date(po.created_at)", "first_assigned"},
         {"count(distinct run.id)", "number_of_runs"},
         {"date(min(run.start_time))", "first_run"},
@@ -36,6 +36,8 @@ defmodule ReportServer.Reports.Portal.ResourceMetricsDetailsReport do
         # The "exists" clause is so that portal_learners without runs don't count towards "number_of_students"
         "left join portal_learners pl on (pl.offering_id = po.id and pl.student_id = psc.student_id
             and exists (select 1 from portal_runs r2 where r2.learner_id = pl.id))",
+        "left join portal_students pst on (pst.id = pl.student_id)",
+        "left join users stu on (stu.id = pst.user_id)",
         "left join portal_runs run on (run.learner_id = pl.id)",
       ]],
       group_by: "ea.id, pt.id, u.id",

--- a/server/lib/report_server/reports/portal/resource_metrics_summary_report.ex
+++ b/server/lib/report_server/reports/portal/resource_metrics_summary_report.ex
@@ -8,7 +8,7 @@ defmodule ReportServer.Reports.Portal.ResourceMetricsSummaryReport do
         {"count(distinct pt.id)", "number_of_teachers"},
         {"count(distinct ps.id)", "number_of_schools"},
         {"count(distinct pc.id)", "number_of_classes"},
-        {"count(distinct pl.student_id)", "number_of_students"}
+        {"count(distinct coalesce(stu.primary_account_id, stu.id))", "number_of_students"}
       ],
       from: "external_activities ea",
       join: [[
@@ -23,6 +23,8 @@ defmodule ReportServer.Reports.Portal.ResourceMetricsSummaryReport do
         # The "exists" clause is so that portal_learners without runs don't count towards "# students started"
         "left join portal_learners pl on (pl.offering_id = po.id and pl.student_id = psc.student_id
           and exists (select 1 from portal_runs r2 where r2.learner_id = pl.id))",
+        "left join portal_students pst on (pst.id = pl.student_id)",
+        "left join users stu on (stu.id = pst.user_id)",
         "left join portal_runs run on (run.learner_id = pl.id)",
       ]],
       group_by: "ea.id",


### PR DESCRIPTION
[REPORT-16](https://concord-consortium.atlassian.net/browse/REPORT-16)

Updates Summary Metrics by Assignment, Detailed Metrics by Assignment, and Teacher Status reports to only count one student for activity by any of a students primary/secondary accounts.

Also adds the CLUE links to work postprocessing step to the Student activity with metadata report.


[REPORT-16]: https://concord-consortium.atlassian.net/browse/REPORT-16?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ