### PR TITLE
fix: Exclude CC users learner data query [REPORT-29]

### DIFF
--- a/server/lib/report_server/reports/athena/learner_data.ex
+++ b/server/lib/report_server/reports/athena/learner_data.ex
@@ -91,15 +91,20 @@ defmodule ReportServer.Reports.Athena.LearnerData do
       {join, where}
     end
 
-    {join, where} = if exclude_internal do
+    internal_teacher_ids = if exclude_internal do
+      get_internal_teacher_ids(user.portal_server)
+    else
+      []
+    end
+
+    {join, where} = if exclude_internal && length(internal_teacher_ids) > 0 do
       {
         [
-          "JOIN portal_teachers pt ON (pt.id = ptc.teacher_id)",
-          "JOIN users teacher_u ON u.id = pt.user_id"
+          "JOIN portal_teachers pt ON (pt.id = ptc.teacher_id)"
           | join,
         ],
         [
-          "teacher_u.email NOT LIKE '%@concord.org'"
+          "pt.id NOT IN #{list_to_in(internal_teacher_ids)}"
           | where
         ]
       }

--- a/server/lib/report_server/reports/athena/student_actions_report.ex
+++ b/server/lib/report_server/reports/athena/student_actions_report.ex
@@ -7,7 +7,7 @@ defmodule ReportServer.Reports.Athena.StudentActionsReport do
     hide_names = report_filter.hide_names
     learner_cols = ReportQuery.get_minimal_learner_cols(hide_names: hide_names)
     with {:ok, learner_data} <- LearnerData.fetch_and_upload(report_filter, user),
-    {:ok, query} <- ReportQuery.get_athena_query(report_filter, learner_data, learner_cols) do
+         {:ok, query} <- ReportQuery.get_athena_query(report_filter, learner_data, learner_cols) do
       {:ok, query}
     else
       error -> error

--- a/server/lib/report_server/reports/portal/resource_metrics_details_report.ex
+++ b/server/lib/report_server/reports/portal/resource_metrics_details_report.ex
@@ -48,11 +48,11 @@ defmodule ReportServer.Reports.Portal.ResourceMetricsDetailsReport do
 
   defp apply_filters(report_query = %ReportQuery{},
       %ReportFilter{cohort: cohort, school: school, teacher: teacher, assignment: assignment,
-        exclude_internal: exclude_internal, start_date: start_date, end_date: end_date}, user = %User{}) do
+        exclude_internal: exclude_internal, start_date: start_date, end_date: end_date}, user = %User{portal_server: portal_server}) do
     join = []
     where = []
 
-    where = exclude_internal_accounts(where, exclude_internal)
+    where = exclude_internal_accounts(where, exclude_internal, portal_server)
 
     {join, where} = apply_allowed_project_ids_filter(user, join, where, "ea.id", "pt.id")
 

--- a/server/lib/report_server/reports/portal/resource_metrics_summary_report.ex
+++ b/server/lib/report_server/reports/portal/resource_metrics_summary_report.ex
@@ -35,11 +35,11 @@ defmodule ReportServer.Reports.Portal.ResourceMetricsSummaryReport do
 
   defp apply_filters(report_query = %ReportQuery{},
       %ReportFilter{cohort: cohort, school: school, teacher: teacher, assignment: assignment,
-        exclude_internal: exclude_internal, start_date: start_date, end_date: end_date}, user = %User{}) do
+        exclude_internal: exclude_internal, start_date: start_date, end_date: end_date}, user = %User{portal_server: portal_server}) do
     join = []
     where = []
 
-    where = exclude_internal_accounts(where, exclude_internal)
+    where = exclude_internal_accounts(where, exclude_internal, portal_server)
 
     {join, where} = apply_allowed_project_ids_filter(user, join, where, "ea.id", "pt.id")
 

--- a/server/lib/report_server/reports/portal/teacher_status_report.ex
+++ b/server/lib/report_server/reports/portal/teacher_status_report.ex
@@ -46,11 +46,11 @@ defmodule ReportServer.Reports.Portal.TeacherStatusReport do
 
   defp apply_filters(report_query = %ReportQuery{},
       %ReportFilter{cohort: cohort, school: school, teacher: teacher, assignment: assignment,
-        exclude_internal: exclude_internal, start_date: start_date, end_date: end_date}, user = %User{}) do
+        exclude_internal: exclude_internal, start_date: start_date, end_date: end_date}, user = %User{portal_server: portal_server}) do
     join = []
     where = []
 
-    where = exclude_internal_accounts(where, exclude_internal)
+    where = exclude_internal_accounts(where, exclude_internal, portal_server)
 
     {join, where} = apply_allowed_project_ids_filter(user, join, where, "ea.id", "pt.id")
 

--- a/server/lib/report_server/reports/report_utils.ex
+++ b/server/lib/report_server/reports/report_utils.ex
@@ -18,9 +18,14 @@ defmodule ReportServer.Reports.ReportUtils do
   def have_filter?(nil), do: false
   def have_filter?(filter_list), do: !Enum.empty?(filter_list)
 
-  def exclude_internal_accounts(where, false), do: where
-  def exclude_internal_accounts(where, true) do
-    [ "u.email NOT LIKE '%@concord.org'" | where ]
+  def exclude_internal_accounts(where, false, _portal_server, _teacher_table), do: where
+  def exclude_internal_accounts(where, true, portal_server, teacher_table \\ "pt") do
+    internal_teacher_ids = get_internal_teacher_ids(portal_server)
+    if length(internal_teacher_ids) == 0 do
+      where
+    else
+      [ "#{teacher_table}.id NOT IN #{list_to_in(internal_teacher_ids)}" | where ]
+    end
   end
 
   def apply_start_date(where, start_date, table_name \\ "run") do

--- a/server/lib/report_server/reports/report_utils.ex
+++ b/server/lib/report_server/reports/report_utils.ex
@@ -119,7 +119,20 @@ defmodule ReportServer.Reports.ReportUtils do
         ]
       }
     end
+  end
 
+  # returns the portal_teacher ids for any teacher of a CC school
+  def get_internal_teacher_ids(portal_server) do
+    sql = """
+      select member_id from portal_school_memberships psm where member_type = 'Portal::Teacher' and school_id in (
+        select id from portal_schools ps where name like '%concord consortium%'
+      )
+    """
+    case ReportServer.PortalDbs.query(portal_server, sql) do
+      {:ok, result} ->
+        result.rows |> Enum.map(&(List.first(&1)))
+      {:error, _} -> []
+    end
   end
 
 end


### PR DESCRIPTION
Previously the query was using a "NOT LIKE '%@concord.org'" filter which both caused a full table scan of the users table (which is very large in production).  This caused the query to timeout.

The change is to instead query the database separately if the exclude CC users setting is set to get a list of all teacher ids in schools with "Concord Consortium" in their name and then join against the portal teachers table and exclude those teachers from the result.  This was the original behavior of the exclude CC users checkbox in the old reports.