### PR TITLE
fix: All teachers not showing in Student Actions with Metadata [REPORT-30]

### DIFF
--- a/server/lib/report_server/reports/athena/learner_data.ex
+++ b/server/lib/report_server/reports/athena/learner_data.ex
@@ -204,6 +204,7 @@ defmodule ReportServer.Reports.Athena.LearnerData do
   defp split_id_list(id_list) do
     id_list
       |> String.split(",")
+      |> Enum.map(&String.trim/1)
   end
 
   def key_by_id(maps) do


### PR DESCRIPTION
This fixes a bug where the string of ids, delimited by a space and comma, was being split by comma and then used to lookup teachers in a map.  The split strings were not trimmed which caused all the teachers except the last teacher in the list to have a space.  That space then caused the lookup in the teacher map to fail, except for the last teacher which did not have a space.