### PR TITLE
fix: Bad default value for job overrides in Job#run

### DIFF
--- a/server/lib/report_server/post_processing/job.ex
+++ b/server/lib/report_server/post_processing/job.ex
@@ -15,7 +15,7 @@ defmodule ReportServer.PostProcessing.Job do
     defstruct output: nil, get_input: nil, learners: nil
   end
 
-  def run(job, query_result, job_server_pid, %JobOverrides{} = overrides \\ {}) do
+  def run(job, query_result, job_server_pid, %JobOverrides{} = overrides \\ %JobOverrides{}) do
     with {:ok, preprocessed} <- preprocess_rows(job, query_result, overrides),
          {:ok, result} <- process_rows(job, query_result, job_server_pid, preprocessed, overrides) do
         {:ok, result}


### PR DESCRIPTION
The default is now an empty JobOverrides struct - it was an empty tuple before the fix.  This caused a pattern matching error when the job_server called Job#run.