### PR TITLE
feat: add configurable completion message and alternating assignment [REPORT-68]

### DIFF
--- a/functions/src/tasks/ai4vs-flvs/index.test.ts
+++ b/functions/src/tasks/ai4vs-flvs/index.test.ts
@@ -93,13 +93,13 @@ describe("orchestrator stepResults accumulation", () => {
   it("stepResults contains first step's result when second handler runs", async () => {
     const evalResult = { success: true, message: "8 of 10 completed" };
     mockEvaluateCompletion.mockResolvedValue(evalResult);
-    mockLockActivity.mockResolvedValue({ success: true });
     mockRandomAssignment.mockResolvedValue({ success: true, message: "stub" });
+    mockLockActivity.mockResolvedValue({ success: true });
     mockSendEmail.mockResolvedValue({ success: true });
 
     await ai4vsFlvs("jobs/test", makeJobDoc(), "jwt-token");
 
-    expect(stepResultsSnapshots["lock-activity"]).toEqual({
+    expect(stepResultsSnapshots["random-assignment"]).toEqual({
       "evaluate-completion": evalResult,
     });
   });
@@ -124,17 +124,17 @@ describe("orchestrator stepResults accumulation", () => {
 
   it("does not record the failed step's result when pipeline aborts", async () => {
     mockEvaluateCompletion.mockResolvedValue({ success: true, message: "ok" });
-    mockLockActivity.mockResolvedValue({ success: false, message: "lock failed" });
+    mockRandomAssignment.mockResolvedValue({ success: false, message: "assignment failed" });
 
     await ai4vsFlvs("jobs/test", makeJobDoc(), "jwt-token");
 
-    expect(mockRandomAssignment).not.toHaveBeenCalled();
+    expect(mockLockActivity).not.toHaveBeenCalled();
     expect(mockSendEmail).not.toHaveBeenCalled();
 
     expect(mockMarkComplete).toHaveBeenCalledWith(
       "jobs/test",
       "failure",
-      expect.objectContaining({ message: "lock failed" })
+      expect.objectContaining({ message: "assignment failed" })
     );
   });
 
@@ -145,6 +145,103 @@ describe("orchestrator stepResults accumulation", () => {
     mockSendEmail.mockResolvedValue({ success: true });
 
     await ai4vsFlvs("jobs/test", makeJobDoc(), "jwt-token");
+
+    expect(mockMarkComplete).toHaveBeenCalledWith(
+      "jobs/test",
+      "success",
+      expect.objectContaining({ message: "Done! Your teacher has been notified." })
+    );
+  });
+});
+
+describe("configurable completion message", () => {
+  const makeJobDocWithMessage = (completion_message?: any): IJobDocument => ({
+    platform_id: "https://learn.concord.org",
+    platform_user_id: 12345,
+    resource_link_id: "678",
+    source_key: "test-source",
+    jobInfo: {
+      version: 1,
+      id: "test-job-123",
+      status: "running",
+      request: {
+        task: "ai4vs-flvs",
+        pilot: "spring-2026",
+        ...(completion_message !== undefined ? { completion_message } : {}),
+      },
+      createdAt: Date.now(),
+    },
+  } as IJobDocument);
+
+  const setupAllStepsSuccess = () => {
+    mockEvaluateCompletion.mockResolvedValue({ success: true });
+    mockLockActivity.mockResolvedValue({ success: true });
+    mockRandomAssignment.mockResolvedValue({ success: true });
+    mockSendEmail.mockResolvedValue({ success: true });
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockMarkComplete.mockResolvedValue(undefined);
+    mockSetProcessingMessage.mockResolvedValue(undefined);
+    for (const key of Object.keys(stepResultsSnapshots)) {
+      delete stepResultsSnapshots[key];
+    }
+    setupAllStepsSuccess();
+  });
+
+  it("uses custom completion_message when provided as non-empty string", async () => {
+    await ai4vsFlvs("jobs/test", makeJobDocWithMessage("Great job! You're all set."), "jwt-token");
+
+    expect(mockMarkComplete).toHaveBeenCalledWith(
+      "jobs/test",
+      "success",
+      expect.objectContaining({ message: "Great job! You're all set." })
+    );
+  });
+
+  it("falls back to default when completion_message is not provided", async () => {
+    await ai4vsFlvs("jobs/test", makeJobDocWithMessage(), "jwt-token");
+
+    expect(mockMarkComplete).toHaveBeenCalledWith(
+      "jobs/test",
+      "success",
+      expect.objectContaining({ message: "Done! Your teacher has been notified." })
+    );
+  });
+
+  it("falls back to default when completion_message is empty string", async () => {
+    await ai4vsFlvs("jobs/test", makeJobDocWithMessage(""), "jwt-token");
+
+    expect(mockMarkComplete).toHaveBeenCalledWith(
+      "jobs/test",
+      "success",
+      expect.objectContaining({ message: "Done! Your teacher has been notified." })
+    );
+  });
+
+  it("falls back to default when completion_message is whitespace-only", async () => {
+    await ai4vsFlvs("jobs/test", makeJobDocWithMessage("   \t  "), "jwt-token");
+
+    expect(mockMarkComplete).toHaveBeenCalledWith(
+      "jobs/test",
+      "success",
+      expect.objectContaining({ message: "Done! Your teacher has been notified." })
+    );
+  });
+
+  it("falls back to default when completion_message is a number", async () => {
+    await ai4vsFlvs("jobs/test", makeJobDocWithMessage(42), "jwt-token");
+
+    expect(mockMarkComplete).toHaveBeenCalledWith(
+      "jobs/test",
+      "success",
+      expect.objectContaining({ message: "Done! Your teacher has been notified." })
+    );
+  });
+
+  it("falls back to default when completion_message is a boolean", async () => {
+    await ai4vsFlvs("jobs/test", makeJobDocWithMessage(true), "jwt-token");
 
     expect(mockMarkComplete).toHaveBeenCalledWith(
       "jobs/test",

--- a/functions/src/tasks/ai4vs-flvs/index.ts
+++ b/functions/src/tasks/ai4vs-flvs/index.ts
@@ -16,8 +16,8 @@ interface PipelineStep {
 const PIPELINES: Record<string, PipelineStep[]> = {
   "spring-2026": [
     { name: "evaluate-completion", processingMessage: "Checking your answers\u2026", handler: evaluateCompletion },
-    { name: "lock-activity", processingMessage: "Locking your pre-test\u2026", handler: lockActivity },
     { name: "random-assignment", processingMessage: "Assigning you to a class\u2026", handler: randomAssignment },
+    { name: "lock-activity", processingMessage: "Locking your pre-test\u2026", handler: lockActivity },
     { name: "send-email", processingMessage: "Notifying your teacher\u2026", handler: sendEmail },
   ],
 };
@@ -66,7 +66,14 @@ export const ai4vsFlvs = async (jobPath: string, jobDoc: IJobDocument, firebaseJ
     functions.logger.info(`ai4vs-flvs: step "${step.name}" completed successfully for ${jobPath}`);
   }
 
+  const DEFAULT_COMPLETION_MESSAGE = "Done! Your teacher has been notified.";
+  const customMessage = request.completion_message;
+  const completionMessage =
+    typeof customMessage === "string" && customMessage.trim()
+      ? customMessage
+      : DEFAULT_COMPLETION_MESSAGE;
+
   await markComplete(jobPath, "success", {
-    message: "Done! Your teacher has been notified.",
+    message: completionMessage,
   });
 };

--- a/functions/src/tasks/ai4vs-flvs/index.ts
+++ b/functions/src/tasks/ai4vs-flvs/index.ts
@@ -68,10 +68,8 @@ export const ai4vsFlvs = async (jobPath: string, jobDoc: IJobDocument, firebaseJ
 
   const DEFAULT_COMPLETION_MESSAGE = "Done! Your teacher has been notified.";
   const customMessage = request.completion_message;
-  const completionMessage =
-    typeof customMessage === "string" && customMessage.trim()
-      ? customMessage
-      : DEFAULT_COMPLETION_MESSAGE;
+  const trimmed = typeof customMessage === "string" ? customMessage.trim() : "";
+  const completionMessage = trimmed || DEFAULT_COMPLETION_MESSAGE;
 
   await markComplete(jobPath, "success", {
     message: completionMessage,

--- a/functions/src/tasks/ai4vs-flvs/random-assignment.test.ts
+++ b/functions/src/tasks/ai4vs-flvs/random-assignment.test.ts
@@ -37,8 +37,26 @@ jest.mock("firebase-functions", () => ({
   },
 }));
 
+// Mock firebase-admin for assignment document transactions
+const mockTransactionGet = jest.fn();
+const mockTransactionSet = jest.fn();
+const mockDocRef = { path: "mock-doc-ref" };
+const mockDoc = jest.fn().mockReturnValue(mockDocRef);
+const mockRunTransaction = jest.fn((fn: any) =>
+  fn({ get: mockTransactionGet, set: mockTransactionSet })
+);
+jest.mock("firebase-admin", () => ({
+  __esModule: true,
+  default: {
+    firestore: () => ({
+      doc: (...args: any[]) => mockDoc(...args),
+      runTransaction: (fn: any) => mockRunTransaction(fn),
+    }),
+  },
+}));
+
 // Must import after jest.mock
-import { randomAssignment } from "./random-assignment";
+import { randomAssignment, computeAssignmentDocId, getAlternatingAssignment } from "./random-assignment";
 
 /** Build a mock Firestore answer doc with the given prompt and selected choices. */
 const makeAnswerDoc = (
@@ -139,6 +157,7 @@ const makeContext = (
     resource_link_id: "678",
     source_key: "test-source",
     context_id: "ctx-1",
+    interactiveId: "interactive-1",
     jobInfo: {
       version: 1,
       id: "test-job-123",
@@ -163,6 +182,8 @@ describe("randomAssignment", () => {
     jest.clearAllMocks();
     mockPortalOidcFetch.mockResolvedValue({ status: 200, data: { success: true } });
     mockGetDocs.mockResolvedValue(makeStandardAnswerDocs());
+    // Default: empty assignment document (first student scenario)
+    mockTransactionGet.mockResolvedValue({ exists: false, data: () => undefined });
   });
 
   describe("request parameter validation", () => {
@@ -710,5 +731,200 @@ describe("randomAssignment", () => {
         expect.any(Error)
       );
     });
+  });
+
+  describe("alternating assignment integration", () => {
+    it("returns student-friendly error when transaction fails", async () => {
+      mockRunTransaction.mockRejectedValueOnce(new Error("transaction failed"));
+
+      const result = await randomAssignment(makeContext());
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("Unable to complete your assignment");
+      expect(mockLoggerError).toHaveBeenCalledWith(
+        expect.stringContaining("unexpected error"),
+        expect.any(Error)
+      );
+    });
+
+    it("returns correct class name after alternation to control", async () => {
+      // Simulate second student: nextAssignment is "control"
+      mockTransactionGet.mockResolvedValue({
+        exists: true,
+        data: () => ({
+          strata: {
+            "Female|White|High|Mod1": {
+              nextAssignment: "control",
+              users: { "other-user": "treatment" },
+            },
+          },
+        }),
+      });
+
+      const result = await randomAssignment(makeContext());
+
+      expect(result.success).toBe(true);
+      expect(result.summary).toBe("Assigned to FL-spring-2026-SHARK");
+    });
+
+    it("returns student-friendly error when interactiveId is missing", async () => {
+      const result = await randomAssignment(makeContext({ interactiveId: undefined }));
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("Unable to complete your assignment");
+      expect(mockLoggerError).toHaveBeenCalledWith(
+        expect.stringContaining("interactiveId")
+      );
+    });
+  });
+});
+
+describe("computeAssignmentDocId", () => {
+  it("produces a deterministic hex string for the same inputs", () => {
+    const id1 = computeAssignmentDocId("int-1", "https://learn.concord.org", "rl-1", "ctx-1");
+    const id2 = computeAssignmentDocId("int-1", "https://learn.concord.org", "rl-1", "ctx-1");
+
+    expect(id1).toBe(id2);
+    expect(id1).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("produces different IDs for different inputs", () => {
+    const id1 = computeAssignmentDocId("int-1", "https://learn.concord.org", "rl-1", "ctx-1");
+    const id2 = computeAssignmentDocId("int-2", "https://learn.concord.org", "rl-1", "ctx-1");
+    const id3 = computeAssignmentDocId("int-1", "https://learn.concord.org", "rl-1", "ctx-2");
+
+    expect(id1).not.toBe(id2);
+    expect(id1).not.toBe(id3);
+    expect(id2).not.toBe(id3);
+  });
+});
+
+describe("getAlternatingAssignment", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockTransactionGet.mockResolvedValue({ exists: false, data: () => undefined });
+  });
+
+  it("returns n1 assignment when document does not exist (first student)", async () => {
+    const result = await getAlternatingAssignment(
+      "src-1", "int-1", "plat-1", "rl-1", "ctx-1", "user-1", "Female|White|High|Mod1", "control"
+    );
+
+    expect(result).toBe("control");
+  });
+
+  it("returns opposite of n1 when nextAssignment is set (second student)", async () => {
+    mockTransactionGet.mockResolvedValue({
+      exists: true,
+      data: () => ({
+        strata: {
+          "Female|White|High|Mod1": {
+            nextAssignment: "treatment",
+            users: { "user-1": "control" },
+          },
+        },
+      }),
+    });
+
+    const result = await getAlternatingAssignment(
+      "src-1", "int-1", "plat-1", "rl-1", "ctx-1", "user-2", "Female|White|High|Mod1", "control"
+    );
+
+    expect(result).toBe("treatment");
+  });
+
+  it("returns n1 again on third student (verifies continued alternation)", async () => {
+    mockTransactionGet.mockResolvedValue({
+      exists: true,
+      data: () => ({
+        strata: {
+          "Female|White|High|Mod1": {
+            nextAssignment: "control",
+            users: { "user-1": "control", "user-2": "treatment" },
+          },
+        },
+      }),
+    });
+
+    const result = await getAlternatingAssignment(
+      "src-1", "int-1", "plat-1", "rl-1", "ctx-1", "user-3", "Female|White|High|Mod1", "control"
+    );
+
+    expect(result).toBe("control");
+  });
+
+  it("returns cached assignment without flipping nextAssignment on dedup", async () => {
+    mockTransactionGet.mockResolvedValue({
+      exists: true,
+      data: () => ({
+        strata: {
+          "Female|White|High|Mod1": {
+            nextAssignment: "treatment",
+            users: { "user-1": "control" },
+          },
+        },
+      }),
+    });
+
+    const result = await getAlternatingAssignment(
+      "src-1", "int-1", "plat-1", "rl-1", "ctx-1", "user-1", "Female|White|High|Mod1", "control"
+    );
+
+    expect(result).toBe("control");
+    // Should NOT have written to the document
+    expect(mockTransactionSet).not.toHaveBeenCalled();
+  });
+
+  it("creates document with correct structure on first call", async () => {
+    await getAlternatingAssignment(
+      "src-1", "int-1", "plat-1", "rl-1", "ctx-1", "user-1", "Female|White|High|Mod1", "control"
+    );
+
+    expect(mockTransactionSet).toHaveBeenCalledWith(
+      mockDocRef,
+      expect.objectContaining({
+        type: "ai4vs-flvs-assignments",
+        interactiveId: "int-1",
+        platform_id: "plat-1",
+        resource_link_id: "rl-1",
+        context_id: "ctx-1",
+        strata: {
+          "Female|White|High|Mod1": {
+            nextAssignment: "treatment",
+            users: { "user-1": "control" },
+          },
+        },
+      }),
+      { merge: true }
+    );
+  });
+
+  it("flips nextAssignment to opposite after each new assignment", async () => {
+    // First student gets "treatment" (n1), nextAssignment should flip to "control"
+    await getAlternatingAssignment(
+      "src-1", "int-1", "plat-1", "rl-1", "ctx-1", "user-1", "Female|White|High|Mod2", "treatment"
+    );
+
+    expect(mockTransactionSet).toHaveBeenCalledWith(
+      mockDocRef,
+      expect.objectContaining({
+        strata: expect.objectContaining({
+          "Female|White|High|Mod2": expect.objectContaining({
+            nextAssignment: "control",
+          }),
+        }),
+      }),
+      { merge: true }
+    );
+  });
+
+  it("throws on transaction failure", async () => {
+    mockRunTransaction.mockRejectedValueOnce(new Error("transaction failed"));
+
+    await expect(
+      getAlternatingAssignment(
+        "src-1", "int-1", "plat-1", "rl-1", "ctx-1", "user-1", "Female|White|High|Mod1", "control"
+      )
+    ).rejects.toThrow("transaction failed");
   });
 });

--- a/functions/src/tasks/ai4vs-flvs/random-assignment.ts
+++ b/functions/src/tasks/ai4vs-flvs/random-assignment.ts
@@ -1,5 +1,7 @@
 import * as functions from "firebase-functions";
 import { collection, query, where, getDocs } from "firebase/firestore";
+import { createHash } from "crypto";
+import admin from "firebase-admin";
 import { StepContext, StepResult } from "./types";
 import { getClientFirestore } from "../../firebase-client";
 import { portalOidcFetch } from "../portal-api";
@@ -214,6 +216,68 @@ const mapToCategory = (dimension: Dimension, choiceTexts: string[]): string => {
   }
 };
 
+// --- Assignment document helpers ---
+
+export const computeAssignmentDocId = (
+  interactiveId: string,
+  platform_id: string,
+  resource_link_id: string,
+  context_id: string,
+): string => {
+  const input = `ai4vs-flvs-assignments|${interactiveId}|${platform_id}|${resource_link_id}|${context_id}`;
+  return createHash("sha256").update(input).digest("hex");
+};
+
+export const getAlternatingAssignment = async (
+  source_key: string,
+  interactiveId: string,
+  platform_id: string,
+  resource_link_id: string,
+  context_id: string,
+  platform_user_id: string,
+  stratumKey: string,
+  n1Assignment: "treatment" | "control",
+): Promise<"treatment" | "control"> => {
+  const db = admin.firestore();
+  const docId = computeAssignmentDocId(interactiveId, platform_id, resource_link_id, context_id);
+  const docRef = db.doc(`sources/${source_key}/jobs-task-data/${docId}`);
+
+  return db.runTransaction(async (tx) => {
+    const doc = await tx.get(docRef);
+    const data = doc.data() || {};
+    const strata = data.strata || {};
+    const stratum = strata[stratumKey] || {};
+    const users = stratum.users || {};
+
+    // Dedup: if user already assigned, return cached assignment
+    if (users[platform_user_id]) {
+      return users[platform_user_id] as "treatment" | "control";
+    }
+
+    // Determine assignment: use nextAssignment if set, otherwise n1
+    const assignment: "treatment" | "control" = stratum.nextAssignment || n1Assignment;
+    const opposite: "treatment" | "control" = assignment === "treatment" ? "control" : "treatment";
+
+    // Write back
+    tx.set(docRef, {
+      type: "ai4vs-flvs-assignments",
+      interactiveId,
+      platform_id,
+      resource_link_id,
+      context_id,
+      strata: {
+        ...strata,
+        [stratumKey]: {
+          nextAssignment: opposite,
+          users: { ...users, [platform_user_id]: assignment },
+        },
+      },
+    }, { merge: true });
+
+    return assignment;
+  });
+};
+
 // --- Main step function ---
 
 export const randomAssignment = async ({
@@ -240,15 +304,16 @@ export const randomAssignment = async ({
     return { success: false, message: STUDENT_FAILURE_MESSAGE };
   }
 
-  const { source_key, platform_user_id, platform_id, resource_link_id, context_id } = jobDoc;
+  const { source_key, platform_user_id, platform_id, resource_link_id, context_id, interactiveId } = jobDoc;
 
-  if (!source_key || !platform_user_id || !platform_id || !resource_link_id || !context_id) {
+  if (!source_key || !platform_user_id || !platform_id || !resource_link_id || !context_id || !interactiveId) {
     const missing = [
       !source_key && "source_key",
       !platform_user_id && "platform_user_id",
       !platform_id && "platform_id",
       !resource_link_id && "resource_link_id",
       !context_id && "context_id",
+      !interactiveId && "interactiveId",
     ].filter(Boolean).join(", ");
     functions.logger.error(`random-assignment: missing required context fields: ${missing} for ${jobPath}`);
     return { success: false, message: STUDENT_FAILURE_MESSAGE };
@@ -306,13 +371,19 @@ export const randomAssignment = async ({
 
     // Look up assignment
     const stratumKey = `${categories.Gender}|${categories.Race}|${categories.Grade}|${categories.Module}`;
-    const assignment = ASSIGNMENT_TABLE[stratumKey];
-    if (!assignment) {
+    const n1Assignment = ASSIGNMENT_TABLE[stratumKey];
+    if (!n1Assignment) {
       functions.logger.error(
         `random-assignment: no matching stratum for ${stratumKey} for user ${platform_user_id} at ${jobPath}`
       );
       return { success: false, message: STUDENT_FAILURE_MESSAGE };
     }
+
+    const assignment = await getAlternatingAssignment(
+      source_key, String(interactiveId), String(platform_id),
+      String(resource_link_id), String(context_id),
+      String(platform_user_id), stratumKey, n1Assignment,
+    );
 
     const className = CLASS_NAMES[assignment];
     const classId = assignment === "treatment" ? treatmentClassId : controlClassId;

--- a/specs/REPORT-68-ai4vs-fit-and-finish.md
+++ b/specs/REPORT-68-ai4vs-fit-and-finish.md
@@ -1,0 +1,143 @@
+# AI4VS "I'm Done" Button Fit and Finish
+
+**Jira**: https://concord-consortium.atlassian.net/browse/REPORT-68
+
+**Status**: **Closed**
+
+## Overview
+
+Two fit-and-finish changes to the AI4VS FLVS "I'm Done" button pipeline: (1) make the final success message configurable via `request.completion_message` with a default fallback, and (2) alternate treatment/control assignments within each demographic stratum using a persistent Firebase assignment document with per-student deduplication.
+
+## Requirements
+
+### Configurable done message
+
+- R1: The pipeline success message must be configurable via an optional `request.completion_message` parameter.
+- R2: If the parameter is not provided, is not a string, or is empty/whitespace-only after trimming, the current default message ("Done! Your teacher has been notified.") must be used.
+- R3: No template variable substitution is required for the done message.
+
+### Alternating treatment/control assignment
+
+- R4: Within each stratum bucket, students must be assigned alternately between treatment and control classes. The assignment document stores a `nextAssignment` field per stratum. If null or missing (first student), the `ASSIGNMENT_TABLE` value is used. After each assignment, `nextAssignment` is flipped to the opposite class.
+- R5: A persistent assignment document must be maintained in the `sources/{source_key}/jobs-task-data/` collection with a deterministic document ID derived from a SHA-256 hash of a pipe-delimited string: `"ai4vs-flvs-assignments|{interactiveId}|{platform_id}|{resource_link_id}|{context_id}"`. All five fields must be present and non-empty. The document must have a `type` field with value `"ai4vs-flvs-assignments"`, store the scoping fields for human readability, and contain a `strata` map. Each stratum entry stores `nextAssignment` and a `users` map keyed by `platform_user_id` with the assignment key (`"treatment"` or `"control"`) as the value.
+- R6: The lookup/update of the assignment document must use a Firestore transaction (Admin SDK) to ensure atomic read-modify-write.
+- R7: If the assignment document does not yet exist for an offering (first student), it must be created automatically. The first student in each bucket always gets the n1 assignment.
+- R8: The existing `ASSIGNMENT_TABLE` continues to define the "n1" (first) assignment for each stratum. No changes to the table values.
+- R9: The step must continue to return `{ success: true, summary: "Assigned to <class_name>" }` with the actual assigned class name.
+- R14: If a student has already been assigned within the same stratum and offering scope, the step must return the same assignment without flipping `nextAssignment` (deduplication).
+
+### Error handling
+
+- R10: If the Firebase transaction for the assignment document fails, the step must fail with a descriptive error logged and a student-friendly message returned.
+
+### Testing
+
+- R12: Unit tests cover configurable done message with custom value, missing/empty/whitespace-only/non-string parameter falling back to default.
+- R13: Unit tests cover alternating assignments, assignment document creation, transaction correctness, correct class name in summary, and deduplication.
+
+## Technical Notes
+
+- **Assignment document ID**: `SHA-256("ai4vs-flvs-assignments|{interactiveId}|{platform_id}|{resource_link_id}|{context_id}")` as a hex string. Direct document get by ID — no query or composite index needed.
+- **`interactiveId` source**: `jobDoc.interactiveId` — a whitelisted context field from the LTI launch context, stable across all student submissions for the same interactive.
+- **Admin SDK for assignment document**: Admin SDK used for the transaction; Client SDK continues for reading student answers. No Firestore security rules needed for `jobs-task-data`.
+- **Alternation logic**: Read `strata[key].nextAssignment` — if null/missing, use `ASSIGNMENT_TABLE[key]`. Flip to opposite after assigning. Store user assignment in `strata[key].users[platform_user_id]` for deduplication.
+- **Document size**: ~50 bytes per user entry. At 10,000 students, ~500KB — well within Firestore's 1MB doc limit.
+- **Pipeline step reordering**: Pipeline order changed to evaluate-completion → **random-assignment → lock-activity** → send-email. If random assignment fails, the activity remains unlocked so the student can retry.
+
+## Out of Scope
+
+- Changes to the `ASSIGNMENT_TABLE` values themselves.
+- Changes to the button interactive or activity authoring.
+- Retroactive rebalancing of students already assigned.
+- Template variable substitution in the done message.
+- Changes to the failure message (already configurable in evaluate-completion).
+
+## Decisions
+
+### What request parameter name for the configurable done message?
+**Context**: The done message needs a parameter name in the `request` object, following existing naming conventions.
+**Options considered**:
+- A) `done_message`
+- B) `success_message`
+- C) `completion_message`
+
+**Decision**: C) `completion_message`
+
+---
+
+### What Firebase path should the assignment document use?
+**Context**: The document needs to be scoped per offering to track alternating assignments. The existing data model uses `sources/{source_key}/...` as the top-level path.
+**Options considered**:
+- A) `sources/{source_key}/assignment-counters/{resource_link_id}` — a single document per offering with stratum keys as fields
+- B) `sources/{source_key}/assignment-counters/{resource_link_id}/strata/{stratum_key}` — one document per stratum per offering
+- C) A top-level collection outside `sources/`
+
+**Decision**: `sources/{source_key}/jobs-task-data/` — a generic collection for task data, reusable by other tasks in the future. The document has `type: "ai4vs-flvs-assignments"` and uses a deterministic SHA-256 document ID derived from scoping fields (no query needed).
+
+---
+
+### Should the assignment document use Admin SDK or Client SDK for the transaction?
+**Context**: The random-assignment step uses the Client SDK for reading student answers. The assignment document is server-side state, not per-user data.
+**Options considered**:
+- A) Admin SDK — cleaner for server-side state, no security rules needed, but mixes SDKs in the step
+- B) Client SDK — consistent with existing code, but requires new Firestore security rules
+
+**Decision**: A) Admin SDK — server-side state doesn't need security rules, and Admin SDK is already available in the functions environment.
+
+---
+
+### What is the correct offering-scoping key for the assignment document?
+**Context**: The document must be unique per offering. Several fields on the job document could serve as the scoping key.
+**Options considered**:
+- A) `resource_link_id` alone
+- B) `context_id + resource_link_id`
+- C) `source_key + resource_link_id`
+
+**Decision**: `platform_id + resource_link_id + context_id` — all three fields stored on the document. The document lives under `sources/{source_key}/jobs-task-data/` so `source_key` is implicit in the path. Additionally, `interactiveId` and `type` are included in the hash to ensure uniqueness across interactives and task types.
+
+---
+
+### How should the assignment document be uniquely identified?
+**Context**: Auto-generated Firestore IDs require a query to find the document; a deterministic ID enables direct get-by-ID.
+
+**Decision**: Use a deterministic document ID derived from `SHA-256(type|interactiveId|platform_id|resource_link_id|context_id)` as a hex string. This eliminates the need for queries and composite indexes. The scoping fields are also stored on the document for human readability.
+
+---
+
+### What document structure for tracking alternating assignments?
+**Context**: The document needs to track which class to assign next and which students have already been assigned (for deduplication).
+**Options considered**:
+- A) Nested map with per-stratum `count` and `users`
+- B) Flat counters map + separate users map
+- C) Derive count from users map (no explicit counter)
+- D) Store `nextAssignment` directly (no counter at all) + `users` map for dedup
+
+**Decision**: D) Store `nextAssignment` per stratum (the class to assign next, flipped after each assignment) and a `users` map keyed by `platform_user_id`. No counter needed — `nextAssignment` directly tells you what to do next. If null/missing, fall back to the `ASSIGNMENT_TABLE` value (n1).
+
+---
+
+### Should the dedup path skip the Portal enrollment call?
+**Context**: When a student re-runs the pipeline and hits the dedup path, the cached assignment is returned. The Portal `add_to_class` API is idempotent.
+
+**Decision**: Left to implementation — either skipping or repeating the Portal call produces the correct outcome. The Portal API handles re-enrollment idempotently (RIGSE-338).
+
+---
+
+### Idempotency: duplicate pipeline runs and the assignment state
+**Context**: If a student triggers the pipeline twice, the alternation state could drift if the counter/nextAssignment is updated on each run.
+
+**Decision**: Added R14 — deduplicate by `platform_user_id` per stratum. On re-runs, return the cached assignment from the `users` map without flipping `nextAssignment`.
+
+---
+
+### Alternating assignment is predictable, not random
+**Context**: The alternation pattern is fully deterministic and predictable, which could be a concern for allocation concealment in a randomized controlled trial.
+
+**Decision**: No change needed — the alternating pattern is the explicit experiment design from the researcher, not an approximation of randomization. Students don't observe or control the counter.
+
+---
+
+### Pipeline step ordering
+**Context**: The original pipeline order was evaluate-completion → lock-activity → random-assignment → send-email. If random assignment fails after locking, the student can't retry.
+
+**Decision**: Reordered to evaluate-completion → **random-assignment → lock-activity** → send-email. If random assignment fails, the activity remains unlocked so the student can retry after correcting any issues.


### PR DESCRIPTION
- Make pipeline success message configurable via request.completion_message with default fallback (trim, type-check, whitespace rejection)
- Implement alternating treatment/control assignment within each stratum using a persistent Firebase document with Admin SDK transactions
- Add per-student deduplication via users map in assignment document
- Reorder pipeline: random-assignment now runs before lock-activity so students can retry if assignment fails
- Add interactiveId to context field validation
- Export computeAssignmentDocId and getAlternatingAssignment for testing

Spec: specs/REPORT-68-ai4vs-fit-and-finish.md