### PR TITLE
docs: call out the separate firestore rules deploy step [REPORT-84]

### DIFF
--- a/functions/README.md
+++ b/functions/README.md
@@ -132,7 +132,7 @@ The deploy will fail with clear instructions if any required secrets are missing
 * set the current project to production: `firebase use report-service-pro`
 * deploy the functions: `npm run deploy` (this generates the build info)
 * if `../firestore.rules` changed, also deploy the rules (see [Deploying rules](#deploying-rules))
-* if the release adds a new query shape, exercise it in production and create any index it asks for (see [Indexes](#indexes))
+* if the release adds a new query shape, deploy its index too: `firebase deploy --only firestore:indexes` (see [Indexes](#indexes))
 * Return to the safety of development: `firebase use report-service-dev`
 
 Deploying will also run the firebase linter, and may also ask you to update or add new indexes to the database,
@@ -145,21 +145,21 @@ from the functions deploy.
 
 ### Indexes
 
-`../firestore.indexes.json` does not currently track any composite indexes, so a query needing one is not
-covered by a deploy. Firestore auto-creates single-field indexes, but a query combining an equality filter
-with an `orderBy` on a different field needs a composite index that has to be created explicitly.
+Composite indexes are tracked in `../firestore.indexes.json` and deployed with
+`firebase deploy --only firestore:indexes`. Firestore auto-creates single-field indexes, but a query
+combining an equality filter with an `orderBy` on a different field needs a composite index, and those
+have to be declared.
 
-In development these usually get created ad hoc, by following the console link in the "requires an index"
-error the first time the query runs. That link only creates the index in the project you were testing
-against, so an index added while testing `report-service-dev` will **not** exist in `report-service-pro`.
+That file is the source of truth for a deploy: it CREATES indexes it lists that the project is missing,
+and it proposes DELETING indexes the project has that the file does not list. Read the plan before
+confirming, especially against production.
 
-**For now**, after deploying a release that adds a new query shape, exercise the new feature against
-production and create any index it asks for by clicking the link shown in the console error. The index
-takes a few minutes to build, and the query keeps failing until it finishes.
-
-**FUTURE**: populate `../firestore.indexes.json` with the composite indexes we actually rely on, so
-`firebase deploy --only firestore:indexes` creates them per project and this stops being a manual
-post-deploy step.
+A release that adds a new query shape needs its index added to the file. If one is missing the query fails
+at runtime with `failed-precondition`, and the error carries a console link that creates the index, but
+only in the project you were running against, which is how the two projects drift apart. Clicking the link
+is a fine way to unblock yourself; adding the same index to the file is what stops it recurring in the
+other project. A newly created index takes a few minutes to build, and the query keeps failing until it
+finishes.
 
 ## API functions
 

--- a/functions/README.md
+++ b/functions/README.md
@@ -130,7 +130,7 @@ The deploy will fail with clear instructions if any required secrets are missing
 
 * update the version number in functions/package.json
 * set the current project to production: `firebase use report-service-pro`
-* deploy the functions:`npm run deploy` (this generates the build info)
+* deploy the functions: `npm run deploy` (this generates the build info)
 * if `../firestore.rules` changed, also deploy the rules (see [Deploying rules](#deploying-rules))
 * if the release adds a new query shape, exercise it in production and create any index it asks for (see [Indexes](#indexes))
 * Return to the safety of development: `firebase use report-service-dev`
@@ -221,7 +221,7 @@ To run the emulator you need java installed.
 
 ### Deploying rules
 
-`cd .. && firebase deploy --only firestore:rules`
+    cd .. && firebase deploy --only firestore:rules
 
 This deploys to whichever project `firebase use` currently selects, so check that first. Nothing in CI
 deploys the rules, and `npm run deploy` in this folder only deploys functions, so a rules change reaches

--- a/functions/README.md
+++ b/functions/README.md
@@ -124,16 +124,42 @@ The deploy will fail with clear instructions if any required secrets are missing
 
 * set the current project to dev: `firebase use report-service-dev`
 * deploy the functions: `npm run deploy` (this generates the build info)
+* if `../firestore.rules` changed, also deploy the rules (see [Deploying rules](#deploying-rules))
 
 ### To deploy to the production server:
 
 * update the version number in functions/package.json
 * set the current project to production: `firebase use report-service-pro`
 * deploy the functions:`npm run deploy` (this generates the build info)
+* if `../firestore.rules` changed, also deploy the rules (see [Deploying rules](#deploying-rules))
+* if the release adds a new query shape, exercise it in production and create any index it asks for (see [Indexes](#indexes))
 * Return to the safety of development: `firebase use report-service-dev`
 
 Deploying will also run the firebase linter, and may also ask you to update or add new indexes to the database,
 depending on the queries it finds.
+
+**`npm run deploy` does not deploy the firestore rules.** It resolves to `firebase deploy --only functions`,
+so a release that changes `../firestore.rules` needs the separate rules deploy called out above. Missing it
+is easy to misdiagnose, because the symptom is a `permission-denied` in the *client* rather than any error
+from the functions deploy.
+
+### Indexes
+
+`../firestore.indexes.json` does not currently track any composite indexes, so a query needing one is not
+covered by a deploy. Firestore auto-creates single-field indexes, but a query combining an equality filter
+with an `orderBy` on a different field needs a composite index that has to be created explicitly.
+
+In development these usually get created ad hoc, by following the console link in the "requires an index"
+error the first time the query runs. That link only creates the index in the project you were testing
+against, so an index added while testing `report-service-dev` will **not** exist in `report-service-pro`.
+
+**For now**, after deploying a release that adds a new query shape, exercise the new feature against
+production and create any index it asks for by clicking the link shown in the console error. The index
+takes a few minutes to build, and the query keeps failing until it finishes.
+
+**FUTURE**: populate `../firestore.indexes.json` with the composite indexes we actually rely on, so
+`firebase deploy --only firestore:indexes` creates them per project and this stops being a manual
+post-deploy step.
 
 ## API functions
 
@@ -196,3 +222,7 @@ To run the emulator you need java installed.
 ### Deploying rules
 
 `cd .. && firebase deploy --only firestore:rules`
+
+This deploys to whichever project `firebase use` currently selects, so check that first. Nothing in CI
+deploys the rules, and `npm run deploy` in this folder only deploys functions, so a rules change reaches
+an environment only when someone runs this command against it.


### PR DESCRIPTION
Docs only. **Not required for the Functions 1.7.0 release** — this can merge whenever, independently of REPORT-84.

## Why

`npm run deploy` in `functions/` resolves to `firebase deploy --only functions`, so it does not carry the firestore rules. Rules deployment was already documented under `Deploying rules`, but neither deploy checklist pointed at it, which makes it easy to skip during a release.

The failure mode is unpleasant to diagnose: the functions deploy succeeds with no error, and the problem surfaces later as a `permission-denied` in the client. On the chat tutor work that reads as a generic "tutor unavailable", which looks like a functions bug rather than a missing deploy step.

## Changes

- Cross-link the rules deploy from both the dev and production checklists, conditional on `../firestore.rules` having changed.
- Add a callout under the production checklist explaining that `npm run deploy` is functions-only.
- Note on `Deploying rules` that it targets whatever `firebase use` currently selects, and that nothing in CI runs it.
- Add an `Indexes` section describing the tracked-index workflow: the file is the source of truth for a deploy (it creates what it lists and proposes deleting what it does not), a new query shape needs its index added to the file, and clicking the console link from a `failed-precondition` error only creates the index in the project you were running against, which is how the two projects drift apart.

No behavior changes, no code touched.

## Depends on #401

The `Indexes` section describes `firestore.indexes.json` as populated, which #401 makes true. Merge that first, or this ships documentation describing a file that is still empty.
