### PR TITLE
Functions 1.7.0: log-first authoring host, object_store rules, version bump

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -135,6 +135,18 @@ service cloud.firestore {
       allow update: if studentWorkUpdate();
     }
 
+    match /sources/{source}/object_store_data/{document=**} {
+      allow create: if studentWorkCreate();
+      allow read: if studentWorkRead();
+      allow update: if studentWorkUpdate();
+    }
+
+    match /sources/{source}/object_store_metadata/{document=**} {
+      allow create: if studentWorkCreate();
+      allow read: if studentWorkRead();
+      allow update: if studentWorkUpdate();
+    }
+
     match /sources/{source}/plugin_states/{document=**} {
       allow create: if studentWorkCreate();
       allow read: if studentWorkRead();

--- a/functions/.env.report-service-dev
+++ b/functions/.env.report-service-dev
@@ -1,2 +1,3 @@
 AWS_S3_BUCKET=concord-staging-report-data
 OPENAI_MODEL=gpt-5.5
+AUTHORING_HOST=authoring.lara.staging.concord.org

--- a/functions/.env.report-service-pro
+++ b/functions/.env.report-service-pro
@@ -1,1 +1,2 @@
 AWS_S3_BUCKET=concord-report-data
+AUTHORING_HOST=authoring.concord.org

--- a/functions/.env.report-service-pro
+++ b/functions/.env.report-service-pro
@@ -1,2 +1,3 @@
 AWS_S3_BUCKET=concord-report-data
+OPENAI_MODEL=gpt-5.5
 AUTHORING_HOST=authoring.concord.org

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "functions",
-  "version": "1.5.0",
+  "version": "1.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "functions",
-      "version": "1.5.0",
+      "version": "1.7.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.11.0",
         "@google-cloud/tasks": "^6.2.1",

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "functions",
-  "version": "1.5.0",
+  "version": "1.7.0",
   "scripts": {
     "lint": "tslint --project tsconfig.json",
     "build": "tsc",

--- a/functions/src/chat-tutor.ts
+++ b/functions/src/chat-tutor.ts
@@ -27,6 +27,10 @@ import { DrainContext, acquireLock, processAndDrain, pickOwnerFields } from "./c
 // multi-line .env escaping. See the note in generic-prompt.ts.
 const openaiKey = defineSecret("OPENAI_API_KEY");
 const openaiModel = defineString("OPENAI_MODEL");
+// Per-project authoring host for the log-first path (no client activityUrl to validate). Set in
+// .env.report-service-dev / .env.report-service-pro; an unset or non-allowlisted value falls back to
+// the allowlist default inside defaultActivityUrl.
+const authoringHost = defineString("AUTHORING_HOST");
 
 const MESSAGES =
   "sources/{source}/chats/{key}/activities/{activityId}/pages/{pageId}/messages/{messageId}";
@@ -60,6 +64,7 @@ export const chatTutorOnWrite = functions
       openai: createOpenAIClient(openaiKey.value()),
       model: openaiModel.value(),
       genericText: CHAT_GENERIC_PROMPT,
+      defaultAuthoringHost: authoringHost.value() || undefined,
     };
 
     try {

--- a/functions/src/chat/drain.ts
+++ b/functions/src/chat/drain.ts
@@ -51,6 +51,9 @@ export interface DrainContext {
   openai: ReturnType<typeof createOpenAIClient>;
   model: string;
   genericText: string;
+  // authoring host used by the log-first path, which has no client activityUrl to validate. Must match
+  // the deployment environment (see defaultActivityUrl); falls back to the allowlist default when unset.
+  defaultAuthoringHost?: string;
 }
 
 // the owner fields the client's rules require on any doc it reads — copied off the
@@ -140,7 +143,7 @@ export function extractUnit(pending: MsgSnap[]): Unit {
 // fetch + assemble the page, then compose the developer-item page prompt. Only called on the first
 // turn (when the developer item is not yet installed), so later turns skip the fetch entirely.
 async function composePageSystemPrompt(ctx: DrainContext, unit: Unit): Promise<string> {
-  const { params, genericText } = ctx;
+  const { params, genericText, defaultAuthoringHost } = ctx;
   const userData = unit.kind === "user" ? unit.docs[0].data() : undefined;
   // a user message supplies + must justify its activityUrl (validated); a log-first turn has no
   // client URL, so fall back to the trusted default authoring host (no client input → no SSRF surface).
@@ -150,7 +153,7 @@ async function composePageSystemPrompt(ctx: DrainContext, unit: Unit): Promise<s
         messageActivityId: String(userData.activityId),
         paramActivityId: params.activityId,
       })
-    : defaultActivityUrl(params.activityId);
+    : defaultActivityUrl(params.activityId, defaultAuthoringHost);
   const activity = await getActivityResource(safeUrl);
   const page = findPage(activity, params.pageId);
   const pageCtx = assemblePageContext(activity, page, orientationHints(userData ?? {}));

--- a/functions/src/chat/fetch-activity.test.ts
+++ b/functions/src/chat/fetch-activity.test.ts
@@ -65,6 +65,25 @@ describe("resolveActivityUrl", () => {
   it("defaultActivityUrl uses the first allowlisted host (log-first path, no client input)", () => {
     expect(defaultActivityUrl("9")).toBe(`https://${AUTHORING_HOSTS[0]}/api/v1/activities/9.json`);
   });
+
+  it("defaultActivityUrl honours a configured allowlisted host so staging fetches staging authoring", () => {
+    const staging = "authoring.lara.staging.concord.org";
+    expect(defaultActivityUrl("9", staging)).toBe(`https://${staging}/api/v1/activities/9.json`);
+  });
+
+  it("defaultActivityUrl ignores a non-allowlisted configured host (a bad .env can't widen the target)", () => {
+    expect(defaultActivityUrl("9", "evil.example.com"))
+      .toBe(`https://${AUTHORING_HOSTS[0]}/api/v1/activities/9.json`);
+  });
+
+  it("defaultActivityUrl falls back to the default host when the config value is empty", () => {
+    expect(defaultActivityUrl("9", "")).toBe(`https://${AUTHORING_HOSTS[0]}/api/v1/activities/9.json`);
+  });
+
+  it("defaultActivityUrl still encodes the path activityId", () => {
+    expect(defaultActivityUrl("9/../evil", "authoring.lara.staging.concord.org"))
+      .toBe("https://authoring.lara.staging.concord.org/api/v1/activities/9%2F..%2Fevil.json");
+  });
 });
 
 describe("parseActivityResource shape checks", () => {

--- a/functions/src/chat/fetch-activity.ts
+++ b/functions/src/chat/fetch-activity.ts
@@ -53,10 +53,16 @@ export function resolveActivityUrl(params: {
 }
 
 // The canonical fetch URL for the default authoring host, for the log-first path where no user
-// message (and so no client activityUrl) exists yet. The host is a trusted constant, so there is no
-// client-controlled input here and no SSRF surface.
-export function defaultActivityUrl(paramActivityId: string): string {
-  return `https://${AUTHORING_HOSTS[0]}/api/v1/activities/${encodeURIComponent(paramActivityId)}.json`;
+// message (and so no client activityUrl) exists yet. There is no client-controlled input here and no
+// SSRF surface: `host` comes from server-side config (the AUTHORING_HOST param, per-project), and is
+// still checked against the allowlist so a misconfigured .env can't widen the fetch target.
+//
+// The host MUST track the deployment environment. Hardcoding AUTHORING_HOSTS[0] made report-service-dev
+// fetch PRODUCTION authoring for every log-first turn, where the same activity id is an unrelated
+// activity — so findPage threw "no visible page matches pageId N" and the turn died with status:"error".
+export function defaultActivityUrl(paramActivityId: string, host?: string): string {
+  const trustedHost = host && AUTHORING_HOSTS.includes(host) ? host : AUTHORING_HOSTS[0];
+  return `https://${trustedHost}/api/v1/activities/${encodeURIComponent(paramActivityId)}.json`;
 }
 
 // Read a Response body enforcing a hard byte cap, streaming when a reader is available (real fetch) and


### PR DESCRIPTION
Three related commits that together make up the Functions 1.7.0 release.

## Commits

**`67bc199` restore object_store rules that existed only in the deployed rulesets**

`object_store_data` and `object_store_metadata` have never been in `firestore.rules` — `git log -S object_store_data --all` finds nothing. They were added through the Firebase console: dev on 2025-12-02 (ruleset `3c995966`), pro on 2026-01-21 (ruleset `2671e419`).

Because the repo never carried them, the rules deploy on 2026-07-06 (ruleset `f3c6420e`, the chat tutor work) silently dropped both blocks from staging. Production kept them only because it had no rules deploy since 2026-04-03. So a rules deploy from this repo was a **regression** for production, not an update: it would have revoked create/read/update on two collections holding live data (`object_store_metadata` under `sources/activity-player.concord.org`, most recent doc 2026-03-30, two READY composite indexes).

Restoring them makes the file a superset of both deployed rulesets. Verified with a whitespace-insensitive diff against the live production ruleset: zero removals.

**`cc34091` derive the log-first authoring host from per-project config**

A log-first turn (forwarded telemetry arriving before any typed message) has no client `activityUrl`, so `composePageSystemPrompt` fell back to `defaultActivityUrl`, which hardcoded `AUTHORING_HOSTS[0]` (`authoring.concord.org`) regardless of deployment project.

On `report-service-dev` that fetched **production** authoring for every log-first turn, where the same activity id is an unrelated activity — so `findPage` threw `no visible page matches pageId N`, the drain died, and the parent doc went to `status:"error"`, surfacing in AP as "The tutor is currently unavailable."

`defaultActivityUrl` now takes an optional host from a new `AUTHORING_HOST` param (same pattern as `OPENAI_MODEL`), set per-project in the `.env` files. The host is still checked against `AUTHORING_HOSTS`, so a mistyped `.env` falls back to the default rather than widening the fetch target — SSRF posture unchanged, still no client-controlled input on this path.

Production was unaffected by the bug: its correct host happened to be the hardcoded one.

**`6a8a2bd` functions 1.7.0 and OPENAI_MODEL for production**

Bumps 1.5.0 → 1.7.0 (skipping 1.6.0, which tagged without ever bumping this file). Also sets `OPENAI_MODEL` for `report-service-pro`, which was only ever set for dev; as a `defineString` with no default it would have returned `""` in production and failed every chat turn silently.

`OPENAI_API_KEY` was likewise absent from `report-service-pro` and was created there separately, outside the repo, along with its `secretAccessor` binding for the App Engine service account.

## Verification

Staging: fresh authenticated conversation drains 19 forwarded log docs with no function errors, replies grounded in the correct activity. `object_store` rules restored (they had been missing for three weeks).

Production: `chatTutorOnWrite` created, rules deployed (additive — `object_store` preserved), both `messages` composite indexes created, authenticated learner on a real production activity got a correctly grounded reply. cc-data-cli verified separately against the `api` function with no 4xx/5xx.

Tests: 6 chat suites, 60 passed / 4 skipped. Lint and `tsc` clean.
