### PR TITLE
chore: track the deployed firestore composite indexes

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,4 +1,509 @@
 {
-  "indexes": [],
-  "fieldOverrides": []
+  "indexes": [
+    {
+      "collectionGroup": "activity_feedbacks",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "platformId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "platformStudentId",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "answers",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "platform_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "resource_link_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "platform_user_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "question_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "id",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "answers",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "platform_user_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "question_id",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "answers",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "question_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "platform_id",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "answers",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "question_type",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "answer",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "answers",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "remote_endpoint",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "question_id",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "answers",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "resource_link_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "platform_user_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "question_id",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "answers",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "resource_url",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "id",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "answers",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "resource_url",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "platform_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "resource_link_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "platform_user_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "id",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "answers",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "run_key",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "id",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "answers",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "run_key",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "question_id",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "answers",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "run_key",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "question_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "id",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "ap_runs",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "platform_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "resource_url",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "context_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "platform_user_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "sequence_activity",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "updated_at",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "ap_runs",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "platform_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "resource_url",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "context_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "platform_user_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "updated_at",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "ap_runs",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "run_key",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "sequence_activity",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "updated_at",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "ap_runs",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "run_key",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "updated_at",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "interactive_state_histories",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "context_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "platform_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "platform_user_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "resource_link_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "created_at",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "interactive_state_histories",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "context_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "platform_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "resource_link_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "created_at",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "interactive_state_histories",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "platform_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "platform_user_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "resource_link_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "created_at",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "messages",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "platform_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "platform_user_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "messages",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "run_key",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "createdAt",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "object_store_metadata",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "context_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "platform_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "platform_user_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "question_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "resource_link_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "created_at",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "object_store_metadata",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "question_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "run_key",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "created_at",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "question_feedbacks",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "platformId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "platformStudentId",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "resources",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "migration_status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "created",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "resources",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "migration_status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "created",
+          "order": "DESCENDING"
+        }
+      ]
+    }
+  ],
+  "fieldOverrides": [
+    {
+      "collectionGroup": "answers_async",
+      "fieldPath": "updated",
+      "ttl": false,
+      "indexes": [
+        {
+          "order": "ASCENDING",
+          "queryScope": "COLLECTION"
+        },
+        {
+          "order": "DESCENDING",
+          "queryScope": "COLLECTION"
+        },
+        {
+          "arrayConfig": "CONTAINS",
+          "queryScope": "COLLECTION"
+        },
+        {
+          "order": "ASCENDING",
+          "queryScope": "COLLECTION_GROUP"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
`firestore.indexes.json` was `{"indexes": [], "fieldOverrides": []}` while both projects carried 26 composite indexes and one field override, so nothing about the index configuration was reproducible from this repo.

Indexes have been created ad hoc, by following the "requires an index" console link at the moment a query first failed. That means a missing index surfaces as a runtime failure in whichever environment happens to run the query first, and it has to be fixed again in the next environment.

The two chat message indexes are a worked example. The anonymous variant `(run_key, createdAt)` existed only in dev; the authenticated variant `(platform_id, platform_user_id, createdAt)` existed in neither. The same `failed-precondition` error had to be hit and fixed separately in each project.

## Production's set, not the union

The two projects had drifted: 23 indexes in common, 3 only in production, 3 only in dev. This commits **production's** 26.

The three dev-only indexes match no query in the current code:

- `answers(resource_url, platform_id, resource_link_id, platform_user_id, run_key, id)` — the auto-importer's learner lookup is either/or: the `platform_id` + `resource_link_id` + `platform_user_id` triple, **or** `run_key` alone. Never the two combined.
- two × `answers_async(updated, resource_url, platform_id, resource_link_id, platform_user_id[, id])` — the only live query on that collection is `.where("updated", "==", true).limit(1300)`, a single equality filter that an automatic single-field index already serves. Production runs that code with no `answers_async` composite index at all.

They look like leftovers from spikes that never landed. Committing the union would have created three unused indexes in production and paid write amplification to maintain them on every write.

## Effect of applying this file

| project | created | deleted |
|---|---|---|
| `report-service-pro` | 0 | 0 |
| `report-service-dev` | 3 | 3 |

A no-op against production; brings dev into line by dropping the three dead indexes and adding the three it lacks.

## Scope

This does not establish that all 26 are needed. Auditing each index against a real query is separate work.

The trailing implicit `__name__` field the admin API reports on every index is dropped, since the config format omits it.