### PR TITLE
Discussion: apply the firestore index audit findings

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -19,46 +19,6 @@
       "queryScope": "COLLECTION",
       "fields": [
         {
-          "fieldPath": "platform_id",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "resource_link_id",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "platform_user_id",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "question_id",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "id",
-          "order": "ASCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "answers",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "platform_user_id",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "question_id",
-          "order": "ASCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "answers",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
           "fieldPath": "question_id",
           "order": "ASCENDING"
         },
@@ -160,38 +120,6 @@
       "fields": [
         {
           "fieldPath": "run_key",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "id",
-          "order": "ASCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "answers",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "run_key",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "question_id",
-          "order": "ASCENDING"
-        }
-      ]
-    },
-    {
-      "collectionGroup": "answers",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "run_key",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "question_id",
           "order": "ASCENDING"
         },
         {
@@ -306,6 +234,36 @@
         },
         {
           "fieldPath": "resource_link_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "created_at",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "interactive_state_histories",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "context_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "platform_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "platform_user_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "resource_link_id",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "shared_with",
           "order": "ASCENDING"
         },
         {


### PR DESCRIPTION
**Draft, for discussion. Nothing here has been deployed to either project, and I am not proposing to deploy it until we agree on what to keep.**

Stacked on #401 so the diff shows only the audit-driven changes rather than re-litigating the snapshot.

An audit matched all 26 committed indexes against the queries in every consumer (`report-service/functions`, `activity-player`, `portal-report`, `question-interactives`) and probed the live databases to confirm its conclusions. Verdict: 15 required, 4 redundant, 7 dead, and one query that needs an index nobody has. Full report is in the global oob file `firestore-index-audit.md`.

## The part that matters: one real defect

```
interactive_state_histories(context_id, platform_id, platform_user_id,
                            resource_link_id, shared_with, created_at)
```

portal-report's `watchCollection` helper (`js/actions/index.ts:371-400`) is invoked for `interactive_state_histories` with `orderBy("created_at","asc")`. When a **learner** views a classmate's class-shared work, the query carries five equality filters plus that `orderBy`. No index in either project contains `shared_with`, so Firestore rejects it.

Confirmed by live probe against **both** projects, independently twice:

```
FAILED_PRECONDITION - The query requires an index.
```

It has gone unnoticed because it needs an uncommon combination: a learner rather than a teacher, a `studentId` param pointing at a peer, and work shared with the class. The sibling `answers` call in the same helper is unaffected, since it is invoked *without* the `orderBy` and is therefore equality-only.

Blast radius is a failed history panel for that student, surfacing as a thrown error on the snapshot listener rather than silently-empty data.

## Removals included here (audit confidence: HIGH)

```
answers(platform_id, resource_link_id, platform_user_id, question_id, id)
answers(run_key, question_id, id)
answers(platform_user_id, question_id)
answers(run_key, question_id)
```

All four trace to `scripts/find-duplicate-answer*.js` on `origin/duplicate-answer-cleanup` (`6c24aef`, May 2021), never merged. The scripts are absent from master, so these indexes have outlived their only caller by five years. The fourth is dead twice over, also being a prefix of `(run_key, question_id, id)`.

Worth noting the mechanism, not just the outcome: an unmerged branch created four production indexes that then persisted for five years. That will recur unless index changes are reviewed alongside the code that needs them, which is part of the argument for #401.

## Deliberately NOT included, for discussion

| Index | Audit confidence |
|---|---|
| `answers(resource_link_id, platform_user_id, question_id)` | Medium |
| `answers(question_type, answer)` | Medium-high |
| `answers(resource_url, id)` | Medium-high |
| `resources(migration_status, created ASC)` | Medium-high |

No query was found for any of them, but unlike the four above there is no positive evidence of what created them, so "no query in the repos" is carrying more weight. The audit's own recommendation is to delete the high-confidence four first, watch for `failed-precondition`, then revisit these.

One trap flagged by the audit: `resources(migration_status, created ASC)` is dead only because nothing sorts ascending. The DESCENDING index does **not** cover an ASCENDING sort, so "the DESC one covers it" is not a valid reason to drop it.

## If this were deployed (it has not been)

| project | create | delete |
|---|---|---|
| `report-service-pro` | 1 | 4 |
| `report-service-dev` | 4 | 7 |

Dev's larger numbers are the pre-existing drift #401 documents, not extra changes from this PR.

## Caveat that applies to every removal

"No query in the repos" is not "no query ever". Any of these could still serve an ad-hoc console query, a researcher's local script, or a job living outside `~/projects`. Indexes are cheap to recreate and the failure mode is a loud `failed-precondition` rather than silent corruption, so removal is low-risk and reversible, but it is not zero-risk.

## Questions

1. Add the missing index on its own first, separately from any deletion?
2. Take all four high-confidence deletions now, or stage them?
3. Anyone recognise the four medium-confidence indexes, particularly `answers(question_type, answer)`?