### PR TITLE
fix: stop repeating the step name in evaluate-completion's result message

### DIFF
--- a/functions/src/tasks/ai4vs-flvs/evaluate-completion.ts
+++ b/functions/src/tasks/ai4vs-flvs/evaluate-completion.ts
@@ -10,7 +10,7 @@ export const evaluateCompletion = async ({
   firebaseJwt,
 }: StepContext): Promise<StepResult> => {
   if (!firebaseJwt) {
-    return { success: false, message: "evaluate-completion: missing Firebase JWT" };
+    return { success: false, message: "missing Firebase JWT" };
   }
 
   const { source_key, platform_user_id, platform_id, resource_link_id, context_id } = jobDoc;
@@ -18,7 +18,7 @@ export const evaluateCompletion = async ({
   if (!source_key || !platform_user_id || !platform_id || !resource_link_id || !context_id) {
     return {
       success: false,
-      message: "evaluate-completion: missing required context fields (source_key, platform_user_id, platform_id, resource_link_id, context_id)",
+      message: "missing required context fields (source_key, platform_user_id, platform_id, resource_link_id, context_id)",
     };
   }
 
@@ -28,14 +28,14 @@ export const evaluateCompletion = async ({
   if (rawMinCompleted === undefined || rawMinCompleted === null) {
     return {
       success: false,
-      message: "evaluate-completion: request is missing required parameter min_completed_questions",
+      message: "request is missing required parameter min_completed_questions",
     };
   }
   const minCompleted = Number(rawMinCompleted);
   if (!Number.isInteger(minCompleted) || minCompleted < 1) {
     return {
       success: false,
-      message: `evaluate-completion: min_completed_questions must be a positive integer, got: ${JSON.stringify(rawMinCompleted)}`,
+      message: `min_completed_questions must be a positive integer, got: ${JSON.stringify(rawMinCompleted)}`,
     };
   }
 
@@ -80,7 +80,7 @@ export const evaluateCompletion = async ({
 
     return {
       success: true,
-      message: `evaluate-completion: ${completed} of ${minCompleted} questions completed`,
+      message: `${completed} of ${minCompleted} questions completed`,
     };
   } finally {
     try {


### PR DESCRIPTION
`evaluateCompletion` prefixed every one of its five result messages with `evaluate-completion: `. The pipeline already labels each step by name when it renders the results, so the teacher notification email came out reading:

```
- evaluate-completion: evaluate-completion: 4 of 4 questions completed
```

This drops the prefix from all five messages. The step name still appears, once, from the renderer.

Noticed while running the fall-2026 study setup end to end on staging, where the emails are read rather than just asserted on.

No behaviour change beyond the message text: nothing matches on these strings. 338 tests in `src/tasks/ai4vs-flvs` pass.
