### PR TITLE
fix: permit reading a chat parent doc that does not exist yet

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -212,8 +212,22 @@ service cloud.firestore {
               'interactive_id', 'interactive_url', 'action', 'value', 'data']);
     }
 
+    // A `get` of a document that does not exist evaluates with `resource == null`, so every branch of
+    // studentWorkRead() dereferences null and the read is denied. That denial is what the client sees on
+    // EVERY fresh conversation, because the parent doc is not created until the first send. Firestore
+    // terminates an onSnapshot listener once it invokes the error callback, so the client's authoritative
+    // status channel was being killed before the conversation even started. Permitting the missing-doc
+    // read lets that listener attach and simply report "does not exist" until the doc appears.
+    //
+    // What this exposes is only non-existence: an existing doc still has to pass studentWorkRead(), so a
+    // probe distinguishes "no conversation here" from "denied", keyed on a path that already requires
+    // knowing the run_key (>10 chars, unguessable) or the learner key. No document contents leak.
+    function chatParentRead() {
+      return resource == null || studentWorkRead();
+    }
+
     match /sources/{source}/chats/{key}/activities/{activityId}/pages/{pageId} {
-      allow read:   if studentWorkRead();      // parent must carry owner fields to be readable
+      allow read:   if chatParentRead();       // existing parent must carry owner fields to be readable
       allow create: if chatParentCreate();     // owner fields only — no server-owned fields
       // no client update — lock/cursor/conversation fields are Admin-written (Admin bypasses rules)
 

--- a/tests/chat-rules.test.js
+++ b/tests/chat-rules.test.js
@@ -157,6 +157,21 @@ describe("chat read path: owner fields required on function-written docs", () =>
     await firebase.assertFails(anon.firestore().doc(parent).get());
   });
 
+  it("client CAN read a parent that does not exist yet (every fresh conversation)", async () => {
+    const { parent } = chatPaths();
+    // Nothing is written first: this is the state of a page the student has never chatted on. Denying it
+    // killed the status listener (Firestore tears an onSnapshot down after its error callback) before the
+    // conversation began, which is exactly what chatParentRead()'s `resource == null` branch fixes.
+    const snap = await firebase.assertSucceeds(anon.firestore().doc(parent).get());
+    expect(snap.exists).toBe(false);
+  });
+
+  it("the missing-doc allowance does NOT widen reads of an existing parent owned by someone else", async () => {
+    const { parent } = chatPaths();
+    await adminDb().doc(parent).set({ ...learnerOwner, status: "idle" }); // a learner's conversation
+    await firebase.assertFails(anon.firestore().doc(parent).get());       // anon still cannot read it
+  });
+
   it("function-written assistant reply is VISIBLE to the client's filtered subscription when it carries owner fields", async () => {
     const { messages } = chatPaths();
     await adminDb().collection(messages).add({ run_key: RUN_KEY, kind: "user", text: "q", createdAt: 1 });


### PR DESCRIPTION
## Problem

A `get` of a document that does not exist evaluates with `resource == null`, and every branch of `studentWorkRead()` dereferences `resource.data`. So a read of a not-yet-created chat parent doc was denied rather than returning "does not exist".

That denial hit the activity-player client on **every fresh conversation**, because the parent doc is not created until the student's first send. Firestore terminates an `onSnapshot` listener once it invokes the error callback, so the client's authoritative status channel was torn down before the conversation began, leaving the tutor-unavailable signal unreachable for the life of the mount. The client carries a bounded reattach for this, but it burned all five attempts on a denial that is expected rather than exceptional.

This is the third of the three fixes suggested for finding 2 of the activity-player AP-126 review, and the only one that removes the cause rather than working around it.

## Change

A `chatParentRead()` helper on the chat parent's `allow read`:

```
function chatParentRead() {
  return resource == null || studentWorkRead();
}
```

## Security

What this exposes is **only non-existence**. An existing doc still has to pass `studentWorkRead()`, so a probe can distinguish "no conversation here" from "denied" on a path that already requires knowing the `run_key` (>10 chars, unguessable) or the learner key. No document contents leak.

The `messages` subcollection is untouched. A `list` there is already evaluated per returned document, and a non-existent doc is never in a result set, so this changes nothing for queries.

## Tests

Two added to `tests/chat-rules.test.js`:

- a parent that does not exist yet is readable, and reports `exists === false`
- the missing-doc allowance does **not** widen reads of an existing parent owned by someone else

Full rules suite passes: 4 files, 172 tests.

```
cd tests && npx firebase -c ../firebase.json emulators:exec --only firestore "npm test"
```

## Deployment

**Already deployed to both projects** (2026-08-04): `report-service-dev` ruleset `d058e8c0` (08:41Z) and `report-service-pro` ruleset `ea82a1e0` (09:14Z).

Before each deploy I diffed the live ruleset against `origin/master`; both were byte-identical, so nothing deployed-only was clobbered and the only delta in each new ruleset is this change. No repeat of the drift that produced 67bc199. Deployed with `--only firestore:rules`, leaving `firestore.indexes.json` untouched.

Verified after each deploy: the live ruleset is byte-identical to the commit, and against a live activity-player client the `[chat] parent read error (permission-denied)` warning that used to appear on every fresh conversation is gone. Covered anonymous and authenticated-learner paths on dev, and anonymous on pro.

**Both projects are therefore ahead of master until this merges.** If a rules deploy from master lands first, this is silently reverted, and the only symptom is a console warning on a feature nobody is watching. Worth merging promptly; if that happens, re-deploy afterwards.

Safe to deploy independently of any client release: it only widens a read that was previously denied, so an older client keeps working unchanged. The client-side `permission-denied` handling should stay in place until this has settled, since it is the only thing preventing a "tutor unavailable" banner on every fresh page if this is rolled back.
