### PR TITLE
fix: step over a permanently-failing chat message instead of wedging the conversation

### DIFF
--- a/functions/src/chat/drain.test.ts
+++ b/functions/src/chat/drain.test.ts
@@ -80,16 +80,22 @@ describeEmu("processAndDrain + acquireLock [emulator, fake OpenAI]", () => {
     db = admin.firestore();
   });
 
-  // A fresh isolated per-page path per test.
+  // A fresh isolated per-page path per test. The activityId is unique per test too, NOT a shared "9":
+  // getActivityResource caches the fetched activity at module level keyed by the resolved URL, which is
+  // built from the activityId. A shared id let one test be served the previous test's stubbed activity,
+  // whose page ids do not match, turning a would-be transient failure into a findPage skip.
   const freshPaths = () => {
-    const pageId = `p-${n++}`;
-    const parentRef = db.doc(`sources/s/chats/k/activities/9/pages/${pageId}`);
-    return { parentRef, messagesCol: parentRef.collection("messages"), pageId };
+    const i = n++;
+    const pageId = `p-${i}`;
+    const activityId = `a-${i}`;
+    const parentRef = db.doc(`sources/s/chats/k/activities/${activityId}/pages/${pageId}`);
+    return { parentRef, messagesCol: parentRef.collection("messages"), pageId, activityId };
   };
 
+  // activityId is read back off the parent path, mirroring production where it is a path param.
   const ctxFor = (parentRef: any, messagesCol: any, openai: any, pageId: string): DrainContext => ({
     parentRef, messagesCol,
-    params: { source: "s", key: "k", activityId: "9", pageId },
+    params: { source: "s", key: "k", activityId: parentRef.path.split("/activities/")[1].split("/")[0], pageId },
     openai, model: "test-model", genericText: "generic",
   });
 
@@ -162,19 +168,19 @@ describeEmu("processAndDrain + acquireLock [emulator, fake OpenAI]", () => {
   // message sent afterwards (by a FIXED client) was never reached. The conversation was bricked for
   // that page permanently.
   it("steps over a permanently-failing head message and still answers the ones queued behind it", async () => {
-    const { parentRef, messagesCol, pageId } = freshPaths();
+    const { parentRef, messagesCol, pageId, activityId } = freshPaths();
     // promptInstalled is deliberately NOT set: that is what forces composePageSystemPrompt (and so
     // resolveActivityUrl) to run, which is the only path that can throw a PermanentUnitError.
     await parentRef.set({ run_key: "anon-run-0123456789", status: "generating",
       lockedAt: admin.firestore.FieldValue.serverTimestamp(), conversationId: "conv_test" });
     // head: a disallowed host → PermanentUnitError, forever.
     await messagesCol.doc("bad").set({ kind: "user", text: "q1", createdAt: ts(BASE + 1),
-      run_key: "anon-run-0123456789", activityId: "9",
+      run_key: "anon-run-0123456789", activityId,
       activityUrl: "https://activity-player.concord.org/?activity=https%3A%2F%2Fauthoring.concord.org" });
     // behind it: a well-formed message that must NOT be blocked.
     await messagesCol.doc("good").set({ kind: "user", text: "q2", createdAt: ts(BASE + 2),
-      run_key: "anon-run-0123456789", activityId: "9",
-      activityUrl: "https://authoring.concord.org/api/v1/activities/9.json" });
+      run_key: "anon-run-0123456789", activityId,
+      activityUrl: `https://authoring.concord.org/api/v1/activities/${activityId}.json` });
 
     const openai = makeFakeOpenAI();
     const restoreFetch = stubActivityFetch(pageId);
@@ -199,12 +205,12 @@ describeEmu("processAndDrain + acquireLock [emulator, fake OpenAI]", () => {
   });
 
   it("surfaces the failure when the skipped unit is the LAST thing that happened", async () => {
-    const { parentRef, messagesCol, pageId } = freshPaths();
+    const { parentRef, messagesCol, pageId, activityId } = freshPaths();
     await parentRef.set({ run_key: "anon-run-0123456789", status: "generating",
       lockedAt: admin.firestore.FieldValue.serverTimestamp(), conversationId: "conv_test" });
     // Only the poison pill: nothing queued behind it to prove the tutor still works.
     await messagesCol.doc("bad").set({ kind: "user", text: "q", createdAt: ts(BASE + 1),
-      run_key: "anon-run-0123456789", activityId: "9",
+      run_key: "anon-run-0123456789", activityId,
       activityUrl: "https://activity-player.concord.org/?activity=https%3A%2F%2Fauthoring.concord.org" });
 
     await processAndDrain(ctxFor(parentRef, messagesCol, makeFakeOpenAI(), pageId));
@@ -216,6 +222,40 @@ describeEmu("processAndDrain + acquireLock [emulator, fake OpenAI]", () => {
     expect(after.status).toBe("error");
     expect(after.error).toMatch(/disallowed activity host/);
     expect((await messagesCol.where("kind", "==", "assistant").get()).empty).toBe(true);
+  });
+
+  // Regression for the single-in-flight invariant. acquireLock backs off ONLY while
+  // status === "generating", so a skip that flipped status to "error" mid-drain (while still holding
+  // the lock and still draining) would let a concurrent trigger win the lock and run a SECOND drain on
+  // the same conversation. The skip must persist the reason + cursor and leave status alone.
+  it("keeps status generating while skipping, so the lock is not released mid-drain", async () => {
+    const { parentRef, messagesCol, pageId, activityId } = freshPaths();
+    await parentRef.set({ run_key: "anon-run-0123456789", status: "generating",
+      lockedAt: admin.firestore.FieldValue.serverTimestamp(), conversationId: "conv_test" });
+    await messagesCol.doc("bad").set({ kind: "user", text: "q1", createdAt: ts(BASE + 1),
+      run_key: "anon-run-0123456789", activityId,
+      activityUrl: "https://activity-player.concord.org/?activity=https%3A%2F%2Fauthoring.concord.org" });
+    await messagesCol.doc("next").set({ kind: "user", text: "q2", createdAt: ts(BASE + 2),
+      run_key: "anon-run-0123456789", activityId,
+      activityUrl: `https://authoring.concord.org/api/v1/activities/${activityId}.json` });
+
+    // The unit AFTER the skip fails transiently, so the drain throws before reaching the idle commit.
+    // That leaves the mid-drain state observable, which is exactly what this asserts.
+    const openai = makeFakeOpenAI();
+    openai.responses.create = async () => { throw new Error("503 upstream unavailable"); };
+
+    const restoreFetch = stubActivityFetch(pageId);
+    try {
+      await expect(processAndDrain(ctxFor(parentRef, messagesCol, openai, pageId)))
+        .rejects.toThrow(/503/);
+    } finally {
+      restoreFetch();
+    }
+
+    const after = (await parentRef.get()).data() as any;
+    expect(after.status).toBe("generating");             // lock still held → no concurrent drain
+    expect(after.lastProcessedMessageId).toBe("bad");    // the skip's cursor advance did persist
+    expect(after.error).toMatch(/disallowed activity host/); // and so did the reason
   });
 
   it("does NOT skip a transient failure — it propagates and leaves the cursor put for a retry", async () => {

--- a/functions/src/chat/drain.test.ts
+++ b/functions/src/chat/drain.test.ts
@@ -140,6 +140,103 @@ describeEmu("processAndDrain + acquireLock [emulator, fake OpenAI]", () => {
     expect((await parentRef.get()).data()!.lastProcessedMessageId).toBe("u2");
   });
 
+  // Serve the activity from a stub instead of the network, so the skip test stays hermetic. The jest
+  // env has no AbortController either, which fetchWithGuards needs, so provide a no-op one.
+  const stubActivityFetch = (pageId: string) => {
+    const activity = { version: 2, name: "stub", pages: [{ id: pageId, is_hidden: false, sections: [] }] };
+    const g = global as any;
+    const restore = { fetch: g.fetch, AbortController: g.AbortController };
+    if (!g.AbortController) g.AbortController = class { signal = undefined; abort() { /* no-op */ } };
+    g.fetch = async () => ({
+      ok: true,
+      status: 200,
+      headers: { get: () => "application/json" },
+      text: async () => JSON.stringify(activity),
+    });
+    return () => { g.fetch = restore.fetch; g.AbortController = restore.AbortController; };
+  };
+
+  // Regression for the production wedge on 2026-08-04: a client sent an activityUrl whose host is not
+  // on AUTHORING_HOSTS, resolveActivityUrl threw, and because the cursor only advances on success the
+  // poisoned doc stayed at the queue HEAD. Every later trigger re-failed on it, so a well-formed
+  // message sent afterwards (by a FIXED client) was never reached. The conversation was bricked for
+  // that page permanently.
+  it("steps over a permanently-failing head message and still answers the ones queued behind it", async () => {
+    const { parentRef, messagesCol, pageId } = freshPaths();
+    // promptInstalled is deliberately NOT set: that is what forces composePageSystemPrompt (and so
+    // resolveActivityUrl) to run, which is the only path that can throw a PermanentUnitError.
+    await parentRef.set({ run_key: "anon-run-0123456789", status: "generating",
+      lockedAt: admin.firestore.FieldValue.serverTimestamp(), conversationId: "conv_test" });
+    // head: a disallowed host → PermanentUnitError, forever.
+    await messagesCol.doc("bad").set({ kind: "user", text: "q1", createdAt: ts(BASE + 1),
+      run_key: "anon-run-0123456789", activityId: "9",
+      activityUrl: "https://activity-player.concord.org/?activity=https%3A%2F%2Fauthoring.concord.org" });
+    // behind it: a well-formed message that must NOT be blocked.
+    await messagesCol.doc("good").set({ kind: "user", text: "q2", createdAt: ts(BASE + 2),
+      run_key: "anon-run-0123456789", activityId: "9",
+      activityUrl: "https://authoring.concord.org/api/v1/activities/9.json" });
+
+    const openai = makeFakeOpenAI();
+    const restoreFetch = stubActivityFetch(pageId);
+    try {
+      // Must not throw: the whole point is that the poison pill no longer aborts the drain.
+      await processAndDrain(ctxFor(parentRef, messagesCol, openai, pageId));
+    } finally {
+      restoreFetch();
+    }
+
+    const after = (await parentRef.get()).data() as any;
+    expect(after.lastProcessedMessageId).toBe("good");   // cursor moved PAST the poison pill
+    expect(after.lockedAt).toBeUndefined();              // lock released, conversation not wedged
+    // A later success supersedes the skip: the tutor demonstrably works, so the conversation must NOT
+    // be left in `error` or the client shows "tutor unavailable" directly above a good reply.
+    expect(after.status).toBe("idle");
+    expect(after.error).toBeUndefined(); // and the stale reason is cleared, not left to mislead
+
+    // the queued-behind message really was answered
+    const assistants = (await messagesCol.where("kind", "==", "assistant").get()).docs.map(d => d.data());
+    expect(assistants).toHaveLength(1);
+  });
+
+  it("surfaces the failure when the skipped unit is the LAST thing that happened", async () => {
+    const { parentRef, messagesCol, pageId } = freshPaths();
+    await parentRef.set({ run_key: "anon-run-0123456789", status: "generating",
+      lockedAt: admin.firestore.FieldValue.serverTimestamp(), conversationId: "conv_test" });
+    // Only the poison pill: nothing queued behind it to prove the tutor still works.
+    await messagesCol.doc("bad").set({ kind: "user", text: "q", createdAt: ts(BASE + 1),
+      run_key: "anon-run-0123456789", activityId: "9",
+      activityUrl: "https://activity-player.concord.org/?activity=https%3A%2F%2Fauthoring.concord.org" });
+
+    await processAndDrain(ctxFor(parentRef, messagesCol, makeFakeOpenAI(), pageId));
+
+    const after = (await parentRef.get()).data() as any;
+    expect(after.lastProcessedMessageId).toBe("bad");    // still unblocked for the next message
+    expect(after.lockedAt).toBeUndefined();
+    // the dropped turn is reported rather than silently swallowed as a healthy idle
+    expect(after.status).toBe("error");
+    expect(after.error).toMatch(/disallowed activity host/);
+    expect((await messagesCol.where("kind", "==", "assistant").get()).empty).toBe(true);
+  });
+
+  it("does NOT skip a transient failure — it propagates and leaves the cursor put for a retry", async () => {
+    const { parentRef, messagesCol, pageId } = freshPaths();
+    await parentRef.set({ run_key: "anon-run-0123456789", status: "generating",
+      conversationId: "conv_test", promptInstalled: true });
+    await messagesCol.doc("u1").set({ kind: "user", text: "q", createdAt: ts(BASE + 1),
+      run_key: "anon-run-0123456789" });
+
+    // A transient OpenAI outage. Skipping this would silently swallow the student's message with no
+    // reply and no error, so it must keep the old behaviour: throw, and leave the cursor alone.
+    const openai = makeFakeOpenAI();
+    openai.responses.create = async () => { throw new Error("503 upstream unavailable"); };
+
+    await expect(processAndDrain(ctxFor(parentRef, messagesCol, openai, pageId)))
+      .rejects.toThrow(/503/);
+
+    const after = (await parentRef.get()).data() as any;
+    expect(after.lastProcessedMessageId).toBeUndefined(); // cursor did NOT advance → u1 is retried
+  });
+
   it("acquireLock is single-in-flight and reclaims a stale lock", async () => {
     const { parentRef } = freshPaths();
     const owner = { run_key: "anon-run-0123456789" };

--- a/functions/src/chat/drain.ts
+++ b/functions/src/chat/drain.ts
@@ -325,8 +325,11 @@ export async function processAndDrain(ctx: DrainContext): Promise<void> {
       console.error(`[chat] skipping permanently-failed unit ${last.id}: ${message}`);
       skippedError = message;
       lastSnap = last;
+      // Persist the reason + the cursor advance, but deliberately NOT `status`. We still hold the lock
+      // and are about to keep draining, and acquireLock only backs off while status === "generating":
+      // flipping it to "error" here would let a concurrent trigger win the lock and run a SECOND drain
+      // on this conversation. The final status is decided once, at the idle commit below.
       await parentRef.set({
-        status: "error",
         error: message,
         lastProcessedCreatedAt: last.get("createdAt"),
         lastProcessedMessageId: last.id,

--- a/functions/src/chat/drain.ts
+++ b/functions/src/chat/drain.ts
@@ -9,6 +9,7 @@ import { assemblePageContext, renderPageContext, OrientationHints } from "./chat
 import { getVisiblePages } from "./page-walk";
 import { Activity, Page } from "./types";
 import { resolveActivityUrl, defaultActivityUrl, getActivityResource } from "./fetch-activity";
+import { PermanentUnitError } from "./permanent-error";
 import { getSimPromptFragments } from "./sim-prompts";
 import {
   createOpenAIClient, createConversation, installDeveloperPrompt, createTutorResponse, TutorInputMessage,
@@ -83,7 +84,11 @@ function orientationHints(data: any): OrientationHints {
 function findPage(activity: Activity, pageId: string): Page {
   const pages = getVisiblePages(activity);
   const found = pages.find(p => String(p.id) === String(pageId));
-  if (!found) throw new Error(`no visible page matches pageId ${pageId}`);
+  // PermanentUnitError: the pageId comes from the path, so this fails identically on every retry for
+  // this conversation. Strictly it could self-heal if an author later un-hides the page (the fetch is
+  // cached for CACHE_TTL_MS), but blocking every later message until that happens is far worse than
+  // dropping the one turn that asked about a page the student can no longer be on.
+  if (!found) throw new PermanentUnitError(`no visible page matches pageId ${pageId}`);
   return found;
 }
 
@@ -251,6 +256,13 @@ export async function processAndDrain(ctx: DrainContext): Promise<void> {
     if (cursorSnap.exists) lastSnap = cursorSnap as MsgSnap;
   }
 
+  // Set when a unit was stepped over as a poison pill, so the idle commit below can settle to `error`
+  // instead of a healthy-looking `idle` after dropping a student's turn. CLEARED by any later unit that
+  // succeeds: `status` describes the conversation NOW, and a skip followed by a good answer means the
+  // tutor is working. Leaving it set showed the client's "tutor unavailable" banner directly above a
+  // perfectly good reply.
+  let skippedError: string | undefined;
+
   for (let i = 0; i < MAX_DRAIN_TURNS; i++) {
     const batch = await afterCursorQuery(lastSnap).get();
     const pending = batch.docs.filter(isPending);
@@ -275,10 +287,20 @@ export async function processAndDrain(ctx: DrainContext): Promise<void> {
         if (check.docs.length === DRAIN_BATCH) return false; // saturated race → keep draining, don't idle
         const stillPending = check.docs.filter(isPending);
         if (stillPending.length > 0) return false;
-        tx.set(parentRef, {
-          status: "idle",
-          lockedAt: admin.firestore.FieldValue.delete(),
-        }, { merge: true });
+        // A drain whose LAST outcome was a skip must NOT settle to a healthy-looking `idle`: the student
+        // asked something and will never get an answer to it, and `error` is what the client surfaces as
+        // "tutor unavailable". If a later unit succeeded, skippedError was cleared above and we settle to
+        // `idle`, because the tutor is working now. The lock is released either way, and acquireLock
+        // proceeds on anything != "generating", so the next message drains normally.
+        // Clear a stale `error` when settling to idle. It is written alongside status:"error" and was
+        // never cleared, so a recovered conversation kept carrying the text of a long-since-fixed
+        // failure — harmless to the client (which reads `status`) but actively misleading when
+        // querying Firestore to find broken conversations.
+        tx.set(parentRef, skippedError
+          ? { status: "error", error: skippedError, lockedAt: admin.firestore.FieldValue.delete() }
+          : { status: "idle", error: admin.firestore.FieldValue.delete(),
+              lockedAt: admin.firestore.FieldValue.delete() },
+        { merge: true });
         return true;
       });
       if (wentIdle) return;
@@ -286,9 +308,33 @@ export async function processAndDrain(ctx: DrainContext): Promise<void> {
     }
 
     const unit = extractUnit(pending);
-    const { assistant, parentUpdate } = await processUnit(ctx, unit);
-
     const last = unit.docs[unit.docs.length - 1];
+
+    let processed;
+    try {
+      processed = await processUnit(ctx, unit);
+    } catch (e) {
+      // Transient failures must keep the OLD behaviour: propagate, leave the cursor put, and let the
+      // next trigger retry. Skipping one would silently swallow the student's message.
+      if (!(e instanceof PermanentUnitError)) throw e;
+      // Poison pill: this unit fails identically forever, and the cursor only advances on success, so
+      // leaving it at the head wedges the whole conversation (every later message blocked behind it).
+      // Step over it, remember the error, and keep draining so queued messages still get answered.
+      // console.error keeps it in the function logs, which the rethrow used to provide.
+      const message = (e as Error).message;
+      console.error(`[chat] skipping permanently-failed unit ${last.id}: ${message}`);
+      skippedError = message;
+      lastSnap = last;
+      await parentRef.set({
+        status: "error",
+        error: message,
+        lastProcessedCreatedAt: last.get("createdAt"),
+        lastProcessedMessageId: last.id,
+      }, { merge: true });
+      continue;
+    }
+    const { assistant, parentUpdate } = processed;
+
     lastSnap = last;
     // commit the assistant doc + earned parent state + cursor advance in ONE batch: either all
     // land or none, so a crash between the reply and the cursor can't duplicate the assistant doc (a
@@ -302,6 +348,8 @@ export async function processAndDrain(ctx: DrainContext): Promise<void> {
       lastProcessedMessageId: last.id,
     }, { merge: true });
     await writeBatch.commit();
+    // A successful turn supersedes an earlier skip: the conversation is demonstrably working again.
+    skippedError = undefined;
   }
 
   // Pathological drain length. Throw so the catch sets status:"error" (self-heals — acquire proceeds on

--- a/functions/src/chat/fetch-activity.ts
+++ b/functions/src/chat/fetch-activity.ts
@@ -10,6 +10,7 @@
 // version===1 resources are run through the lifted convertLegacyResource; v2 pass through. Results are
 // cached by URL (module-level, per-instance) with a TTL so a mid-pilot author edit self-heals.
 import { convertLegacyResource } from "./convert";
+import { PermanentUnitError } from "./permanent-error";
 import { Activity } from "./types";
 
 // Only these hosts may be fetched (the authoring hosts). https is also required.
@@ -39,15 +40,21 @@ export function resolveActivityUrl(params: {
   paramActivityId: string;
 }): string {
   const { activityUrl, messageActivityId, paramActivityId } = params;
+  // All four rejections below are PermanentUnitError: they are decided entirely by fields ON the
+  // message doc, so re-running against the same doc always fails the same way. See permanent-error.ts.
   let u: URL;
   try {
     u = new URL(activityUrl);
   } catch (e) {
-    throw new Error("invalid activityUrl");
+    throw new PermanentUnitError("invalid activityUrl");
   }
-  if (u.protocol !== "https:") throw new Error("activityUrl must use https");
-  if (!AUTHORING_HOSTS.includes(u.hostname)) throw new Error(`disallowed activity host: ${u.hostname}`);
-  if (String(messageActivityId) !== String(paramActivityId)) throw new Error("activityId mismatch");
+  if (u.protocol !== "https:") throw new PermanentUnitError("activityUrl must use https");
+  if (!AUTHORING_HOSTS.includes(u.hostname)) {
+    throw new PermanentUnitError(`disallowed activity host: ${u.hostname}`);
+  }
+  if (String(messageActivityId) !== String(paramActivityId)) {
+    throw new PermanentUnitError("activityId mismatch");
+  }
   // Path param is authoritative — build the URL from the trusted host + path id, not the raw client string.
   return `https://${u.hostname}/api/v1/activities/${encodeURIComponent(paramActivityId)}.json`;
 }

--- a/functions/src/chat/permanent-error.ts
+++ b/functions/src/chat/permanent-error.ts
@@ -1,0 +1,22 @@
+// A unit failure that will fail identically on every retry.
+//
+// The drain's cursor only advances past a unit on SUCCESS, which is what makes a deterministic
+// failure at the queue HEAD block that conversation forever: each trigger re-reads the same message,
+// throws the same error, and never reaches the messages queued behind it. Observed in production on
+// 2026-08-04, where a client sent an activityUrl whose host is not on the AUTHORING_HOSTS allowlist;
+// the conversation stayed wedged even after a corrected client sent a well-formed message, because
+// the poisoned doc still sat at the head.
+//
+// Throwing THIS type marks a failure as "retrying cannot help", which lets processAndDrain skip the
+// unit and keep draining. Everything else keeps the old behaviour and propagates, because a transient
+// failure (OpenAI 5xx, cold-start timeout, network) MUST be retried rather than skipped: skipping one
+// would silently swallow a student's message with no reply and no error, which is worse than a
+// visible stuck state. Only throw this where the input itself is the problem.
+export class PermanentUnitError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PermanentUnitError";
+    // Error subclassing across the TS/ES5 target boundary breaks `instanceof` without this.
+    Object.setPrototypeOf(this, PermanentUnitError.prototype);
+  }
+}


### PR DESCRIPTION
## Problem

The drain's cursor only advances past a unit on **success**. So a message that fails deterministically at the queue **head** blocks that conversation forever: every trigger re-reads the same doc, throws the same error, and never reaches the messages queued behind it.

This is the risk `chat-tutor.ts` already documents, with the exact cause named:

> Accepted risk: the cursor only advances past a unit on success, so a queue-HEAD message that fails deterministically (removed page / **bad client activityUrl**) re-fails each trigger and blocks later messages in THAT one conversation ... a poison-pill skip is a future item.

This PR is that future item.

## It happened in production

On 2026-08-04 an activity-player client sent an `activityUrl` whose host is not on `AUTHORING_HOSTS`, so `resolveActivityUrl` threw `disallowed activity host: activity-player.concord.org`.

The conversation then stayed wedged **even after a corrected client sent a well-formed message to the same page**. Firestore state at that point:

```
parent: status=error, error="disallowed activity host: activity-player.concord.org",
        lastProcessedMessageId=(absent)   ← cursor never advanced
messages:
  [0] host=activity-player.concord.org   ← poisoned, still at the head
  [1] host=authoring.concord.org         ← well-formed, never processed
```

The client-side cause is fixed separately in activity-player. This PR makes the backend survive it, and any future deterministic failure, rather than bricking a page's tutor permanently.

## Why not just advance the cursor on any failure

Because a failure is not evidence that retrying cannot help. Skipping a transient OpenAI 5xx, a cold-start timeout, or a network blip would **silently swallow a student's message** with no reply and no error, which is worse than a visible stuck state.

So the distinction is drawn at the throw site. A new `PermanentUnitError` marks failures decided entirely by fields **on the message doc**, which therefore fail identically on every retry:

- `resolveActivityUrl`: non-URL, non-https, disallowed host, activityId mismatch
- `findPage`: no visible page matches the path's pageId

Everything else is untouched and still propagates for a retry.

## Behaviour

On a `PermanentUnitError` the drain now:

1. logs it with `console.error` (the rethrow used to be what put it in the function logs),
2. records `status:"error"` plus the message on the parent,
3. advances the cursor past the unit,
4. **keeps draining**, so messages queued behind it are still answered.

The status only **stays** `error` if the skip was the last thing that happened. A later successful unit clears it and the drain settles to `idle`, because `status` describes the conversation *now*. Staging showed why that matters: leaving it set put the client's "tutor unavailable" banner directly above a perfectly good reply. The lock is released either way, and `acquireLock` proceeds on anything != `generating`, so the next message drains normally.

Settling to `idle` also clears the `error` field. It was written alongside `status:"error"` and never cleared, so a recovered conversation kept carrying the text of a long-since-fixed failure: harmless to the client, which reads `status`, but actively misleading when querying Firestore to find broken conversations.

One deliberate judgement call: `findPage` could in principle self-heal if an author un-hides a page (the fetch is cached for `CACHE_TTL_MS`). Blocking every later message until that happens is worse than dropping the single turn that asked about a page the student can no longer be on, so it is treated as permanent. Noted in a comment at the throw site.

## Tests

Three emulator-backed tests, each of which fails against the old behaviour for the right reason:

- **the wedge regression**: poison pill at the head with a well-formed message behind it. Asserts the drain does not throw, the cursor advances past the poison to the good message, the good message is actually answered, and the conversation settles to `idle` with the stale `error` cleared.
- **skip as the last outcome**: only a poison pill, nothing behind it. Asserts the cursor still advances (so the conversation is unblocked) but the parent reports `error` with the reason, rather than a healthy-looking `idle` that silently swallowed the turn.
- **transient failures are not skipped**: an OpenAI failure still propagates and leaves the cursor put, so the message is retried rather than dropped.

The skip tests stub the activity fetch (and polyfill `AbortController`, absent in this jest env) to stay hermetic.

Full functions suite: 26 files, 504 tests. `tsc --noEmit` and `tslint` clean.

## Verified on staging and production

Deployed to `report-service-dev` and `report-service-pro` (`--only functions:chatTutorOnWrite`).

**Two conversations on dev had been wedged since 2026-07-27.** Both recovered on the next message: cursor stepped past the poison, prompt installed, reply generated. No migration was needed, which is the same reason none is needed for anyone else.

**On production, the exact failure from earlier that day was re-run.** An authenticated student sent one message from the unfixed client (host `activity-player.concord.org`) and one from the fixed client (host `authoring.concord.org`). Before this change the good message sat unprocessed behind the poisoned one and the parent was stuck with no cursor at all; with it, the poison is skipped, the good message is answered, and the parent ends `idle` with no `error`.

Worth being precise about the limit: this does **not** rescue the current production client on its own, because every message that client sends carries the same bad URL and is its own poison pill. What it guarantees is that a good message is never blocked behind a bad one, so no conversation is permanently bricked once the activity-player fix ships.

## Not included

No migration for conversations already wedged. They unblock on their own on the next message, as demonstrated on dev.
