### PR TITLE
fix: shorten CLUE activity names when the unit is a URL [REPORT-98]

### DIFF
--- a/server/lib/report_server/clue.ex
+++ b/server/lib/report_server/clue.ex
@@ -107,6 +107,13 @@ defmodule ReportServer.Clue do
   ## segments are dropped rather than only the last one, so a versioned directory
   ## cannot leave a filename as the label. Anything that yields nothing usable
   ## falls back to the unit verbatim, which is today's behaviour.
+  ##
+  ## The `://` guard is deliberate, not incidental. A unit served from inside the
+  ## CLUE repository is a relative path, `./demo/units/qa/content.json`, and
+  ## shortening it would label it `qa`, indistinguishable from the unrelated `qa`
+  ## unit on clue-curriculum. Only an absolute URL names the curriculum it came
+  ## from well enough for the directory to stand in for it, so a relative path
+  ## stays verbatim and keeps the two apart.
   defp unit_label(unit) do
     case unit_path_segments(unit) do
       [] -> unit

--- a/server/lib/report_server/clue.ex
+++ b/server/lib/report_server/clue.ex
@@ -83,13 +83,45 @@ defmodule ReportServer.Clue do
   so the runnable URL is deliberately not a fallback: a name repeating it would
   add a redundant wide column and no information. The chain is the parsed label,
   then the unit alone, then a bare "CLUE".
+
+  A unit given as a URL is reduced to its unit name first, so the same guarantee
+  holds when a project deploys its curriculum from a branch.
   """
   def resource_name(runnable_url) do
     query = URI.decode_query(URI.parse(runnable_url).query || "")
     case {blank_to_nil(query["unit"]), blank_to_nil(query["problem"])} do
       {nil, _} -> "CLUE"
-      {unit, nil} -> "CLUE #{unit}"
-      {unit, problem} -> "CLUE #{unit}: Problem #{problem}"
+      {unit, nil} -> "CLUE #{unit_label(unit)}"
+      {unit, problem} -> "CLUE #{unit_label(unit)}: Problem #{problem}"
+    end
+  end
+
+  ## A branch deploy passes the whole content.json URL as the unit, which would
+  ## splice about a hundred characters into a label column and reintroduce the
+  ## exact redundancy the docstring above says this function avoids, since the
+  ## name would then repeat res_N_resource_url.
+  ##
+  ## In CLUE's curriculum layout the directory holding the content file is the
+  ## unit name, so `.../branch/modsAuth/mods/content.json` reduces to `mods` and
+  ## matches what a plain `?unit=mods` produces for the same curriculum. Dotted
+  ## segments are dropped rather than only the last one, so a versioned directory
+  ## cannot leave a filename as the label. Anything that yields nothing usable
+  ## falls back to the unit verbatim, which is today's behaviour.
+  defp unit_label(unit) do
+    case unit_path_segments(unit) do
+      [] -> unit
+      segments -> List.last(segments)
+    end
+  end
+
+  defp unit_path_segments(unit) do
+    if String.contains?(unit, "://") do
+      URI.parse(unit).path
+      |> to_string()
+      |> String.split("/", trim: true)
+      |> Enum.reject(&String.contains?(&1, "."))
+    else
+      []
     end
   end
 

--- a/server/test/report_server/clue_test.exs
+++ b/server/test/report_server/clue_test.exs
@@ -314,6 +314,26 @@ defmodule ReportServer.ClueTest do
         assert name == "CLUE #{unit}"
       end
     end
+
+    test "keeps a relative-path unit verbatim so an in-repo unit stays distinct" do
+      ## A unit served from inside the CLUE repository is a relative path, not a
+      ## URL. Shortening it to its directory would label it "CLUE qa", which
+      ## reads as the unrelated `qa` unit on clue-curriculum, so the two would
+      ## merge into one activity name in the report.
+      in_repo = "./demo/units/qa/content.json"
+
+      assert Clue.resource_name(
+               "https://collaborative-learning.concord.org/?unit=#{in_repo}&problem=1.2"
+             ) ==
+               "CLUE #{in_repo}: Problem 1.2"
+
+      refute Clue.resource_name(
+               "https://collaborative-learning.concord.org/?unit=#{in_repo}&problem=1.2"
+             ) ==
+               Clue.resource_name(
+                 "https://collaborative-learning.concord.org/?unit=qa&problem=1.2"
+               )
+    end
   end
 
   describe "Track A: keys and columns" do

--- a/server/test/report_server/clue_test.exs
+++ b/server/test/report_server/clue_test.exs
@@ -272,6 +272,48 @@ defmodule ReportServer.ClueTest do
         refute name =~ "collaborative-learning.concord.org"
       end
     end
+
+    ## A branch deploy passes the whole content.json URL as the unit. Reported
+    ## verbatim that is about a hundred characters of label sitting beside
+    ## res_N_resource_url, which is the redundancy this function exists to avoid.
+    test "reduces a URL-valued unit to its unit name" do
+      url_unit =
+        "https://collaborative-learning.concord.org/?unit=" <>
+          "https://models-resources.concord.org/clue-curriculum/branch/modsAuth/mods/content.json" <>
+          "&problem=1.2"
+
+      assert Clue.resource_name(url_unit) == "CLUE mods: Problem 1.2"
+    end
+
+    test "a URL-valued unit and a plain unit for the same curriculum agree" do
+      ## The acceptance criterion: one class assigned by branch URL and another
+      ## by unit name must not read as two different activities.
+      url_unit =
+        "https://collaborative-learning.concord.org/?unit=" <>
+          "https://models-resources.concord.org/clue-curriculum/branch/modsAuth/mods/content.json" <>
+          "&problem=1.2"
+
+      plain_unit = "https://collaborative-learning.concord.org/?unit=mods&problem=1.2"
+
+      assert Clue.resource_name(url_unit) == Clue.resource_name(plain_unit)
+    end
+
+    test "a URL-valued unit still shortens when there is no problem" do
+      url_unit =
+        "https://collaborative-learning.concord.org/?unit=" <>
+          "https://models-resources.concord.org/clue-curriculum/branch/modsAuth/mods/content.json"
+
+      assert Clue.resource_name(url_unit) == "CLUE mods"
+    end
+
+    test "falls back to the unit verbatim when a URL yields no usable segment" do
+      ## Better a long label than a wrong one: dropping to a filename or to an
+      ## empty string would be worse than what it replaces.
+      for unit <- ["https://models-resources.concord.org", "https://x.org/content.json"] do
+        name = Clue.resource_name("https://collaborative-learning.concord.org/?unit=#{unit}")
+        assert name == "CLUE #{unit}"
+      end
+    end
   end
 
   describe "Track A: keys and columns" do


### PR DESCRIPTION
Fixes [REPORT-98](https://concord-consortium.atlassian.net/browse/REPORT-98).

## The problem

`resource_name/1` builds the CLUE activity label from the runnable URL's `unit` and `problem` parameters. MODS deploys its curriculum from a branch, so it passes a whole content.json URL as `unit`, and the label became about 100 characters:

```
CLUE https://models-resources.concord.org/clue-curriculum/branch/modsAuth/mods/content.json: Problem 1.2
```

Eight of the nine resources in the production verification run looked like this. Only the one assignment using a plain `?unit=mods` produced the intended shape.

This reintroduced exactly the redundancy the function's own docstring says it avoids. The comment explains that the runnable URL is deliberately *not* a fallback because "a name repeating it would add a redundant wide column and no information", and a URL-valued `unit` puts the URL back in, in a column that already sits beside `res_N_resource_url`.

## The fix

In CLUE's curriculum layout the directory holding the content file is the unit name, so a URL-valued unit reduces to the same label a plain `?unit=` produces for the same curriculum.

Two details worth reviewing:

**Dotted segments are dropped, not just the trailing one.** Removing only the last segment would leave a versioned directory like `unit.v2/` exposed to producing a filename as the label.

**Anything that yields nothing usable falls back to the unit verbatim**, which is today's behavior. A long label is better than a wrong or empty one, so a bare host or a URL whose every segment is dotted stays as-is rather than degrading.

## Verified against production data

Run through the real `resource_name/1` with the nine runnable URLs from the MODS PD Spring 2026 verification run:

| before | after |
|---|---|
| 104 chars, 8 of 9 resources | **22 chars**, all 9 |

All nine now read `CLUE mods: Problem <n.n>`. The one assignment that already used the plain unit form is unchanged, which is the acceptance criterion (URL-valued and plain forms agree) holding on real data rather than only in a fixture.

## Testing

**515 tests, 0 failures**, up from 510. Five new tests: the URL-valued unit shortens; a URL-valued and a plain unit for the same curriculum produce identical labels; the shortening still applies when there is no `problem`; a URL yielding no usable segment falls back to the unit verbatim; and a relative-path unit is kept verbatim rather than shortened.

That last one covers the form raised in review, `unit=./demo/units/qa/content.json`, used when a unit is served from inside the CLUE repository. It already read correctly, because the shortening only applies to a unit containing `://`, but nothing pinned it. The behavior is load-bearing rather than incidental: shortening it would produce `CLUE qa`, indistinguishable from the unrelated `qa` unit on clue-curriculum, so the test asserts both that the path survives and that it does not collide with a plain `?unit=qa`.

The existing three-case fallback chain (parsed label, unit alone, bare `CLUE`) is unchanged and still covered.


[REPORT-98]: https://concord-consortium.atlassian.net/browse/REPORT-98?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
