### PR TITLE
fix: stop emitting NaN in total_percent_complete [REPORT-99]

### DIFF
--- a/server/lib/report_server/reports/athena/shared_queries.ex
+++ b/server/lib/report_server/reports/athena/shared_queries.ex
@@ -108,7 +108,12 @@ defmodule ReportServer.Reports.Athena.SharedQueries do
             %{name: "res_#{res_index}_last_run", value: "learners_and_answers_#{res_index}.last_run"},
             %{name: "res_#{res_index}_total_num_questions", value: "activities_#{res_index}.num_questions"},
             %{name: "res_#{res_index}_total_num_answers", value: "learners_and_answers_#{res_index}.num_answers"},
-            %{name: "res_#{res_index}_total_percent_complete", value: "round(100.0 * learners_and_answers_#{res_index}.num_answers / activities_#{res_index}.num_questions, 1)"},
+            ## nullif guards the zero denominator. Presto returns NaN for 0.0/0
+            ## rather than erroring, so without it the CSV carries the literal
+            ## string "NaN" in a column that is empty everywhere else, and a
+            ## consumer reading it as numeric hits an unexpected token in a few
+            ## scattered rows. NULL renders as an empty cell and matches.
+            %{name: "res_#{res_index}_total_percent_complete", value: "round(100.0 * learners_and_answers_#{res_index}.num_answers / nullif(activities_#{res_index}.num_questions, 0), 1)"},
             %{name: "res_#{res_index}_num_required_questions", value: "learners_and_answers_#{res_index}.num_required_questions"},
             %{name: "res_#{res_index}_num_required_answers", value: "learners_and_answers_#{res_index}.num_required_answers"}
           ]

--- a/server/test/report_server/reports/athena/shared_queries_completion_test.exs
+++ b/server/test/report_server/reports/athena/shared_queries_completion_test.exs
@@ -1,0 +1,81 @@
+defmodule ReportServer.Reports.Athena.SharedQueriesCompletionTest do
+  @moduledoc """
+  Pins the completion-counter columns on the shared answers path.
+
+  The percentage divides the answer count by the question count, and Presto
+  returns NaN for `0.0/0` rather than erroring. Reported verbatim that puts the
+  literal string "NaN" into a column that is an empty string everywhere else, so
+  anything reading it as numeric hits an unexpected token in a few scattered
+  rows rather than failing outright.
+
+  A zero question count is reachable whenever a resource yields no question
+  structure for a learner who is nonetheless enrolled on it.
+  """
+  use ExUnit.Case, async: true
+
+  alias ReportServer.Reports.Athena.SharedQueries
+  alias ReportServer.Reports.ReportFilter
+
+  @auth_domain "https://learn.concord.org"
+
+  ## A resource with no question structure is the case that produces the zero
+  ## denominator, so the fixture is the failing shape rather than a happy one.
+  defp resource_sql(report_type \\ :answers) do
+    resource_data = [
+      %{
+        runnable_url: "https://activity-player.concord.org/branch/master?activity=1",
+        query_id: "q1",
+        resource: nil,
+        denormalized: %{questions: %{}, choices: %{}, question_order: []}
+      }
+    ]
+
+    {:ok, query} =
+      SharedQueries.generate_resource_sql(
+        report_type,
+        %ReportFilter{hide_names: false},
+        resource_data,
+        @auth_domain
+      )
+
+    query.raw_sql
+  end
+
+  describe "total_percent_complete" do
+    test "guards the zero denominator so an empty resource yields NULL, not NaN" do
+      sql = resource_sql()
+
+      assert sql =~ "res_1_total_percent_complete"
+
+      assert sql =~ ~r/round\(100\.0 \* learners_and_answers_1\.num_answers \/ nullif\(activities_1\.num_questions, 0\), 1\)/,
+             "the percentage must divide by nullif(num_questions, 0)"
+    end
+
+    test "never divides by a bare num_questions" do
+      ## The regression this guards: reverting the nullif restores NaN silently,
+      ## because nothing errors and the column still populates for every learner
+      ## who does have questions.
+      sql = resource_sql()
+
+      refute sql =~ ~r/num_answers \/ activities_1\.num_questions/,
+             "an unguarded division reintroduces the literal string NaN"
+    end
+
+    test "leaves the numerator and the rounding alone" do
+      ## Existing non-zero percentages must be unchanged, including their one
+      ## decimal place, so this is a fix rather than a recalculation.
+      sql = resource_sql()
+
+      assert sql =~ "100.0 * learners_and_answers_1.num_answers"
+      assert sql =~ ", 1)"
+    end
+
+    test "the raw counter columns are untouched" do
+      sql = resource_sql()
+
+      assert sql =~ "res_1_total_num_questions"
+      assert sql =~ "res_1_total_num_answers"
+      refute sql =~ ~r/res_1_total_num_questions[^,]*nullif/
+    end
+  end
+end


### PR DESCRIPTION
Fixes [REPORT-99](https://concord-consortium.atlassian.net/browse/REPORT-99).

Based on `master` and independent of the REPORT-36 work, so this can merge in any order.

## The problem

`total_percent_complete` divided the answer count by the question count with no guard:

```sql
round(100.0 * learners_and_answers_N.num_answers / activities_N.num_questions, 1)
```

Presto returns `NaN` for `0.0/0` rather than erroring, so a resource that yields no question structure for a learner who is nonetheless enrolled on it puts the literal four-character string `NaN` into the CSV.

**The inconsistency is the defect rather than the value.** Every other empty cell in the report is an empty string, so anything reading the column as numeric hits an unexpected token in a handful of scattered rows instead of failing cleanly, which is the kind of thing that surfaces much later as a confusing parse error rather than at the point of use.

## Scope is wider than CLUE

`shared_queries.ex:111` is on the **shared** answers path, so this applies to every answers report, not just the CLUE one. CLUE merely makes a zero question count reachable in ordinary use, since an unworked document yields no derived structure at all.

Confirmed this is the only unguarded division in the module and the only place the column is built.

## The fix

```sql
round(100.0 * learners_and_answers_N.num_answers / nullif(activities_N.num_questions, 0), 1)
```

`nullif` yields NULL for a zero denominator, NULL propagates through the multiply and the `round`, and a NULL renders as an empty cell, matching the rest of the report. The numerator and the one-decimal rounding are untouched, so existing non-zero percentages are unchanged.

## Testing

**440 tests, 0 failures** on master plus this change.

New `shared_queries_completion_test.exs`, deliberately a distinct filename rather than `shared_queries_test.exs`, which exists on the REPORT-36 branch and would otherwise collide on merge for no reason.

The fixture is the *failing* shape (a resource with no question structure) rather than a happy one, and **the tests are a real guard, not a restatement of the code**: reverting the `nullif` fails 2 of the 4. The other two assert invariants, that the numerator and rounding are unchanged and that the raw counter columns are untouched, and pass either way by design.

## Confirmed on the engine

Verified against Athena with a literal-only query, **0 bytes scanned**:

```sql
SELECT
  round(100.0 * 0  / nullif(0,  0), 1) AS zero_over_zero,
  round(100.0 * 18 / nullif(25, 0), 1) AS normal_case,
  round(100.0 * 0  / 0, 1)             AS old_behaviour
```

| expression | result |
|---|---|
| `zero_over_zero` | **NULL** |
| `normal_case` | **72.0** |
| `old_behaviour` | **NaN** |

So the guard yields NULL rather than raising, the normal case is untouched including its single decimal place, and the old expression really did produce the literal `NaN` rather than erroring, which is why this reached production unnoticed.

`72.0` is a real value rather than an invented one: it is a learner's actual `res_1_total_percent_complete` from the verification run, 18 answers out of 25 questions.


[REPORT-99]: https://concord-consortium.atlassian.net/browse/REPORT-99?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ