### PR TITLE
Deregister the one-off migrate task def from an EXIT trap

### DIFF
--- a/server/scripts/run-migrate-task.sh
+++ b/server/scripts/run-migrate-task.sh
@@ -87,7 +87,9 @@ WORKDIR="$(mktemp -d)"
 MIG_TD_ARN=""
 cleanup() {
   local rc=$?
-  rm -rf "$WORKDIR"
+  # :? so a future refactor that lets the trap arm before WORKDIR is set aborts here
+  # rather than running rm -rf against an empty path.
+  rm -rf "${WORKDIR:?}"
   if [ -n "$MIG_TD_ARN" ] && [ -z "$KEEP" ]; then
     if "${AWS[@]}" ecs deregister-task-definition --task-definition "$MIG_TD_ARN" \
          --query 'taskDefinition.status' --output text >/dev/null 2>&1; then

--- a/server/scripts/run-migrate-task.sh
+++ b/server/scripts/run-migrate-task.sh
@@ -79,6 +79,30 @@ fi
 
 WORKDIR="$(mktemp -d)"
 
+# Clean up from an EXIT trap rather than at the end of the script. With set -e, any
+# failure between registering the task def and reaching the end (an AWS error, a
+# migration that exits non-zero, Ctrl-C) skipped the old cleanup and left an ACTIVE
+# one-off task def behind. MIG_TD_ARN is the exact revision this run registered, so a
+# concurrent run of the same family cannot make us deregister the wrong one.
+MIG_TD_ARN=""
+cleanup() {
+  local rc=$?
+  rm -rf "$WORKDIR"
+  if [ -n "$MIG_TD_ARN" ] && [ -z "$KEEP" ]; then
+    if "${AWS[@]}" ecs deregister-task-definition --task-definition "$MIG_TD_ARN" \
+         --query 'taskDefinition.status' --output text >/dev/null 2>&1; then
+      echo "deregistered one-off task def: $MIG_TD_ARN"
+    else
+      echo "WARNING: could not deregister $MIG_TD_ARN, remove it manually." >&2
+    fi
+  fi
+  return $rc
+}
+trap cleanup EXIT
+# Route Ctrl-C and TERM through a normal exit so the EXIT trap runs exactly once.
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
 # --- Clone the live task def into a one-off migrate task def -----------------------
 "${AWS[@]}" ecs describe-task-definition --task-definition "$TASKDEF" \
   --query 'taskDefinition' --output json > "$WORKDIR/td-src.json"
@@ -101,11 +125,15 @@ jq --arg fam "$MIGRATE_FAMILY" --arg img "$IMAGE" '{
   "$WORKDIR/td-src.json" > "$WORKDIR/td-migrate.json"
 
 # --- Register + run ----------------------------------------------------------------
-"${AWS[@]}" ecs register-task-definition --cli-input-json "file://$WORKDIR/td-migrate.json" \
-  --query 'taskDefinition.taskDefinitionArn' --output text
+# Capture the exact revision ARN: it is what the EXIT trap deregisters, and running by
+# ARN rather than family name means a concurrent run registering a new revision cannot
+# make us migrate from someone else's image.
+MIG_TD_ARN=$("${AWS[@]}" ecs register-task-definition --cli-input-json "file://$WORKDIR/td-migrate.json" \
+  --query 'taskDefinition.taskDefinitionArn' --output text)
+echo "registered: $MIG_TD_ARN"
 
 TASK_ARN=$("${AWS[@]}" ecs run-task \
-  --cluster "$CLUSTER" --launch-type FARGATE --task-definition "$MIGRATE_FAMILY" \
+  --cluster "$CLUSTER" --launch-type FARGATE --task-definition "$MIG_TD_ARN" \
   --network-configuration "awsvpcConfiguration={subnets=[$SUBNETS],securityGroups=[$SGS],assignPublicIp=$PUBIP}" \
   --started-by "migrate:${IMAGE##*:}" \
   --query 'tasks[0].taskArn' --output text)
@@ -131,14 +159,8 @@ echo "--- migration log ($LOG_GROUP : $LOG_PREFIX/$CONTAINER/$TASK_ID) ---"
   --log-stream-name "$LOG_PREFIX/$CONTAINER/$TASK_ID" \
   --start-from-head --query 'events[].message' --output text || true
 
-# --- Cleanup the one-off task def --------------------------------------------------
-if [ -z "$KEEP" ]; then
-  MIG_TD=$("${AWS[@]}" ecs describe-task-definition --task-definition "$MIGRATE_FAMILY" \
-    --query 'taskDefinition.taskDefinitionArn' --output text)
-  "${AWS[@]}" ecs deregister-task-definition --task-definition "$MIG_TD" \
-    --query 'taskDefinition.status' --output text >/dev/null
-  echo "deregistered one-off task def: $MIG_TD"
-fi
+# The one-off task def is deregistered by the EXIT trap, so it is cleaned up on the
+# failure paths below too, not just here.
 
 if [ "${EXIT:-}" = "0" ]; then
   echo "✅ migrations applied (exit 0). Now safe to flip the service/stack image to: $IMAGE"


### PR DESCRIPTION
Fixes a cleanup leak in `server/scripts/run-migrate-task.sh`.

## The bug

The one-off migrate task definition was only deregistered at the very end of the script. With `set -euo pipefail`, anything that fails between registering it and reaching that point skips the cleanup entirely: an AWS error, a migration task that exits non-zero, or a Ctrl-C. Re-running after a failed migration therefore leaks one task definition revision per attempt.

That was not hypothetical. The production account had accumulated five ACTIVE `report-server-migrate` revisions, all registered on 13 Jan 2025 within 33 minutes of each other, which is the shape of someone re-running a migration that kept failing.

The temp dir was never cleaned up either, since the script had no trap at all.

## The fix

- Cleanup moves into an `EXIT` trap, so it runs on the failure paths too. `INT` and `TERM` route through a normal exit so the trap fires exactly once. The trap also removes the temp dir.
- The registered revision ARN is captured and used for both `run-task` and the deregistration, instead of referring to the task definition by family name.

That second part fixes a real correctness issue, not just tidiness. `run-task` was launching by family name, so if two runs shared a family, the second run's `register-task-definition` could land between the first run's register and run. The first run would then migrate from the *other* run's image. The same race applied to cleanup, which could deregister a revision belonging to a different run.

No behaviour change on the success path: the task definition is still deregistered by default, `--keep` still suppresses it, and the deregistration message still names the ARN.

## Scope

This is the same fix applied to `run-sql-task.sh` in #414. That script was adapted from this one and inherited the bug; Copilot caught it there, which is what surfaced it here. Kept as a separate PR because this script has been running migrations for over a year and deserves review on its own terms rather than riding along with a new-script PR.

## The revisions that had already leaked

The five leaked revisions were deregistered separately from this change, after confirming no task in any state referenced them and no service pointed at the family. Their JSON was captured first, since deregistration cannot be undone in place.

They were not a credential exposure. Each carried `DATABASE_URL` in plaintext env, but the live service task definition does too (23 environment values, zero secrets), so they revealed nothing that ECS read access did not already reveal. Their copy was also dead: it no longer matched the value on the current task definition, so the password had been rotated at some point after January 2025.

Worth knowing for any future cleanup of this kind: deregistering marks a revision `INACTIVE`, which hides it from listings and blocks new tasks from launching, but AWS retains `INACTIVE` revisions indefinitely with no API to purge them. Their environment values remain readable via `describe-task-definition` against the exact ARN. Deregistration is therefore housekeeping, not a way to remove a secret. A genuinely live credential in that position would need rotating instead.
