### PR TITLE
docs: correct the deploy stack names and generalize the migration note

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -111,9 +111,11 @@ The report server is deployed using Docker on CloudFormation.  Here are the step
 1. Run `docker build . -t concordconsortium/report-server:VERSION` where `VERSION` is a semver version.  For staging deployments use `-pre.N` suffixes like `1.1.0-pre.0`.
 2. Once the build is complete run `docker push concordconsortium/report-server:VERSION` to push to the container registry.
 3. Before updating the stack to the new image, apply any new migrations by running `bin/report_server eval "ReportServer.Release.migrate"` in a one-off task/container built from the new image.  (A workstation with DB access can run `MIX_ENV=prod mix ecto.migrate` instead, but `config/runtime.exs` raises unless `SERVER_ACCESS_KEY_ID`, `SERVER_SECRET_ACCESS_KEY`, `REPORT_SERVICE_TOKEN` and `HIDE_USERNAME_HASH_SALT` are also set — migrations do not use them, so any non-empty placeholder works.)
-4. In AWS CloudFormation select the `report-server` stack in the QA account or `report-server-prod` in the production account and run an update using the newly uploaded tagged container as the value for the "ImageUrl" parameter in the update process.
+4. In AWS CloudFormation select the `report-service-qa` stack in the QA account (816253370536) or `report-service-prod` in the production account (612297603577) and run an update using the newly uploaded tagged container as the value for the "ImageUrl" parameter in the update process.  Note that the stack names use `report-service` (matching this repo), not `report-server`.
 
-**For the REPORT-74 release specifically**: the `data_access_log` migration must be applied before the new image serves traffic — the web download paths fail closed against that table.
+Step 3 is not optional whenever the new image contains code that reads a table the running image does not have: those paths fail closed, so the migration must land before the new image serves traffic.  The `data_access_log` table added in the REPORT-74 release is the canonical example.
+
+The version shown in the app header comes from the `version:` field in `mix.exs` (compiled into the release), not from the Docker tag, so bump it in the same commit that cuts a release.  Staging builds carry the `-pre.N` suffix; production builds drop it.
 
 ## Server Setup
 


### PR DESCRIPTION
Found while cutting the server 1.10.0 release: the deploy instructions in `server/README.md` pointed at CloudFormation stacks that do not exist.

## Changes

**Stack names.** Step 4 named the stacks `report-server` (QA) and `report-server-prod` (production). The real names are `report-service-qa` in the QA account (816253370536) and `report-service-prod` in the production account (612297603577), matching this repo's name rather than the container's. Added an explicit note about the `report-service` vs `report-server` trap, since the container image genuinely is `concordconsortium/report-server` and the two are easy to conflate.

**Migration note.** The "For the REPORT-74 release specifically" callout was pinned to a release that shipped two versions ago, which made it read as stale trivia rather than a standing rule. It is restated as the general rule it was always an instance of: step 3 is mandatory whenever the new image reads a table the running image lacks, with `data_access_log` kept as the worked example.

**Version source.** Added a line recording that the version in the app header comes from `version:` in `mix.exs` (compiled into the release), not from the Docker tag, and that staging carries `-pre.N` while production drops it. This is not something the deploy steps said anywhere, and it is easy to push a correctly tagged image that reports the wrong version in the UI.

That third item is slightly beyond the two stale bits I set out to fix, so feel free to ask me to drop it if you would rather keep this PR narrow.